### PR TITLE
Issue 587: Autocomplete

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,5 +26,6 @@
 // Load Sufia and ES6 Javascript
 //= require sufia
 //= require lakeshore
+//= require lakeshore/autocomplete
 //= require lakeshore/asset_type_control
 //= require lakeshore/deleted_files

--- a/app/assets/javascripts/lakeshore.js
+++ b/app/assets/javascripts/lakeshore.js
@@ -2,19 +2,46 @@
 Lakeshore = {
   initialize: function () {
     this.assetTypeControl();
+    this.autocompleteControl(2, "/autocomplete");
+  },
+
+  autocompleteControl: function (length, endpoint) {
+    var ac = require('lakeshore/autocomplete');
+    var controller = new ac.AutocompleteControl();
+
+    // a convenience function for passing to jQuery.each
+    var init = function () { controller.initialize(this, length, endpoint); }
+
+    // a fn to add these event handlers to the correct DOM elements.
+    var propogate = function () {
+      var parent = $(this).parent().parent().parent();
+
+      // re-queue this event handler so that the target DOM element has had a chance
+      // to be created.
+      setTimeout(function() {
+        $(parent).find('input').last().each(init);
+        // recurse, so that this handler is added to the new DOM element
+        $('.base-terms button.add').on('click', propogate);
+      }, 0);
+    };
+
+    $('.base-terms')
+      .find('input[class*="_representation_uris"],input[class*="_document_uris"]')
+      .each(init);
+
+    // add the autocomplete control to the newly created DOM elements
+    $('.base-terms button.add').on('click', propogate);
   },
 
   // This is copied after Sufia.saveWorkControl
   assetTypeControl: function () {
     var at = require('lakeshore/asset_type_control');
     new at.AssetTypeControl($("#asset_type_select")).activate();
-  },
-
+  }
 };
 
 Blacklight.onLoad(function () {
   Lakeshore.initialize();
-  
   if ( $('div.openseadragon-container').length && !$('div.openseadragon-canvas').length) {
     initOpenSeadragon();
   }

--- a/app/assets/javascripts/lakeshore/autocomplete.es6
+++ b/app/assets/javascripts/lakeshore/autocomplete.es6
@@ -1,0 +1,18 @@
+// lakeshore/autocomplete.es6
+export class AutocompleteControl {
+
+  // initialize the provide HTMLElement with a jQuery autocomplete module
+  initialize(el, length, endpoint) {
+    $(el).autocomplete({
+        minLength: length,
+        source: (req, res) => {
+            $.getJSON(endpoint, {q: req.term}, function(data) {
+              // map the JSON structure into a format usable for jQuery.autocomplete
+              res(data.map((x) => ({label: `${x.uid} (${x.prefLabel})`, value: x.uri })));
+            });
+          },
+        focus: () => false,
+        complete: () => $('.ui-autocomplete-loading').removeClass("ui-autocomplete-loading")
+    })
+  }
+}

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+class AutocompleteController < ActionController::Base
+  respond_to :json
+
+  def index
+    respond_to do |format|
+      format.json do
+        res = Blacklight.default_index.connection.get('select', params: build_query(params[:q]))
+        data = res["response"]["docs"].map do |x|
+          { uri: x["fedora_uri_ssim"], uid: x["uid_ssim"], prefLabel: x["pref_label_ssim"] }
+        end
+        render json: data
+      end
+    end
+  end
+
+  private
+
+    def build_query(query)
+      {
+        q: "uid_ssim:" + (query || '') + "*",
+        fl: "pref_label_ssim, uid_ssim, fedora_uri_ssim",
+        fq: "human_readable_type_tesim:Asset"
+      }
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,8 @@ Rails.application.routes.draw do
     resources :list_items, except: [:index, :show]
   end
 
+  resources :autocomplete
+
   get 'relationships/:model/:id', to: 'relationships#show', as: 'relationship_model'
 
   # Lakeshore API


### PR DESCRIPTION
This is only a partial implementation, so you may wish to wait until it is complete before merging.

The main issue is that a number of different JavaScript frameworks are working at cross purposes, so when the "More" button is pressed, it is very difficult to correctly enable the typeahead plugin on the new input field. In principle, this would be incredibly easy, but because of how Sufia copies input fields, it is definitively not easy.

Sufia also has a built-in autocomplete feature, but that feature has very specific constraints that didn't seem to work with our needs here.
