### PR TITLE
Partially addresses #723

### DIFF
--- a/app/assets/javascripts/lakeshore.js
+++ b/app/assets/javascripts/lakeshore.js
@@ -26,7 +26,7 @@ Lakeshore = {
     };
 
     $('.base-terms')
-      .find('input[class*="_representation_uris"],input[class*="_document_uris"]')
+      .find('input[class*="_representation_uris"],input[class*="_document_uris"],input[id$="_preferred_representation_uri"]')
       .each(init);
 
     // add the autocomplete control to the newly created DOM elements

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -18,7 +18,8 @@ class AutocompleteController < ActionController::Base
 
     def build_query(query)
       {
-        q: "uid_ssim:" + (query || '') + "*",
+        q: "*" + (query || '') + "*",
+        df: "pref_label_tesim, uid_tesim",
         fl: "pref_label_ssim, uid_ssim, fedora_uri_ssim",
         fq: "human_readable_type_tesim:Asset"
       }

--- a/app/models/concerns/resource_metadata.rb
+++ b/app/models/concerns/resource_metadata.rb
@@ -29,7 +29,7 @@ module ResourceMetadata
     property :icon, predicate: AIC.icon, multiple: false, class_name: "ActiveFedora::Base"
 
     property :uid, predicate: AIC.uid, multiple: false do |index|
-      index.as :symbol
+      index.as :symbol, :stored_searchable
     end
 
     property :updated, predicate: AIC.updated, multiple: false do |index|

--- a/spec/controllers/autocomplete_controller_spec.rb
+++ b/spec/controllers/autocomplete_controller_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe AutocompleteController do
+  describe "#index" do
+    let!(:asset) { create(:asset, pref_label: "Autocomplete example") }
+
+    before  { get :index, q: query, format: :json }
+    subject { JSON.parse(response.body).first }
+
+    context "with no results" do
+      let(:query) { "Bogus stuff" }
+      it { is_expected.to be_nil }
+    end
+
+    context "with a partial label query" do
+      let(:query) { "complete" }
+      it { is_expected.to include("prefLabel" => ["Autocomplete example"]) }
+    end
+
+    context "with a complete label query" do
+      let(:query) { "Autocomplete example" }
+      it { is_expected.to include("prefLabel" => ["Autocomplete example"]) }
+    end
+
+    context "with a partial UID query" do
+      let(:query) { asset.id.first(4) }
+      it { is_expected.to include("prefLabel" => ["Autocomplete example"]) }
+    end
+  end
+end


### PR DESCRIPTION
Specifically:
- autocomplete now searches both prefLabel and uid
- the preferred representation field also auto-completes

@awead can take it from here.
