### PR TITLE
adding vertical wrapper to simple_form setup

### DIFF
--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,15 +1,23 @@
 # frozen_string_literal: true
 
-# Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
   # Wrappers are used by the form builder to generate a
   # complete input. You can remove any component from the
   # wrapper, change the order or even add your own to the
   # stack. The options given below are used to wrap the
   # whole input.
-  config.wrappers :default, class: :input,
-                            hint_class: :field_with_hint,
-                            error_class: :field_with_errors do |b|
+  config.wrappers :vertical_file_input, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :readonly
+    b.use :label, class: 'control-label'
+
+    b.use :input
+    b.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+    b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+  end
+  config.wrappers :default, class: :input, hint_class: :field_with_hint, error_class: :field_with_errors do |b|
     ## Extensions enabled by default
     # Any of these extensions can be disabled for a
     # given input by passing: `f.input EXTENSION_NAME => false`.
@@ -43,11 +51,9 @@ SimpleForm.setup do |config|
     b.optional :readonly
 
     ## Inputs
-    b.optional :label
-    b.optional :hint,  wrap_with: { tag: :span, class: :hint }
-
+    b.use :label_input
+    b.use :hint,  wrap_with: { tag: :span, class: :hint }
     b.use :error, wrap_with: { tag: :span, class: :error }
-    b.use :input
 
     ## full_messages_for
     # If you want to display the full error message for the attribute, you can
@@ -102,7 +108,7 @@ SimpleForm.setup do |config|
   # config.item_wrapper_class = nil
 
   # How the label text should be generated altogether with the required text.
-  config.label_text = ->(label, required, _) { "#{label} #{required}" }
+  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
 
   # You can define the class to use on all labels. Default is nil.
   # config.label_class = nil

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,31 @@
+en:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/spec/views/curation_concerns/file_sets/_form.html.erb_spec.rb
+++ b/spec/views/curation_concerns/file_sets/_form.html.erb_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'curation_concerns/file_sets/_form.html.erb', type: :view do
+  let(:user)     { create(:user1) }
+  let(:parent)   { create(:still_image_asset) }
+  let(:file_set) { create(:file_set) }
+
+  before do
+    allow(controller).to receive(:current_user).and_return(user)
+    render 'curation_concerns/file_sets/form.html.erb', curation_concern: file_set, parent: parent
+  end
+
+  context "without additional users" do
+    it "draws the edit form without error" do
+      expect(rendered).to have_css("input")
+    end
+  end
+end


### PR DESCRIPTION
hi @awead, I found that adding the wrapper to the simple_form setup block solves the bug (1379 in redmine, the wrapper couldn't be found and the form relying on it didn't load, file_set edit page couldn't render). Not sure how to test though in a view though, or if we need a test for this? 