### PR TITLE
handle unauthorized errors with more info when uploading duplicate asset

### DIFF
--- a/app/assets/stylesheets/aic_styles.scss
+++ b/app/assets/stylesheets/aic_styles.scss
@@ -182,3 +182,7 @@ div.home_share_work {
 table.relationships img {
 	max-height: 150px;
 }
+
+p.unauthorized_asset_title {
+  margin-top: 25%;
+}

--- a/app/controllers/curation_concerns/generic_works_controller.rb
+++ b/app/controllers/curation_concerns/generic_works_controller.rb
@@ -16,6 +16,15 @@ class CurationConcerns::GenericWorksController < ApplicationController
     end
     report_status_and_redirect(asset_with_relationships, batch: false)
   end
+  # we have to override this action in Curation Concerns application controller behavior class
+
+  def deny_access
+    presenter = UnauthorizedPresenter.new(params[:id])
+    render template: '/error/unauthorized',
+           formats: [:html],
+           status: 401,
+           locals: { presenter: presenter }
+  end
 
   protected
 

--- a/app/presenters/unauthorized_presenter.rb
+++ b/app/presenters/unauthorized_presenter.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+class UnauthorizedPresenter
+  def initialize(id)
+    @asset = GenericWork.find(id)
+  end
+
+  def depositor_last_name
+    @asset.aic_depositor.family_name.nil? ? "" : @asset.aic_depositor.family_name
+  end
+
+  def depositor_first_name
+    @asset.aic_depositor.given_name.nil? ? "" : @asset.aic_depositor.given_name
+  end
+
+  def depositor
+    @depositor = depositor_last_name.empty? && depositor_first_name.empty? ? "citi_support@artic.edu" : "#{depositor_first_name} #{depositor_last_name}"
+  end
+
+  def title
+    @asset.to_solr["title_tesim"].first
+  end
+
+  def thumbnail
+    @asset.to_solr["thumbnail_path_ss"]
+  end
+
+  def message
+    "You are not authorized to see this asset. Please contact #{depositor} if you would like to request access to it."
+  end
+end

--- a/app/services/duplicate_upload_verification_service.rb
+++ b/app/services/duplicate_upload_verification_service.rb
@@ -8,7 +8,7 @@ class DuplicateUploadVerificationService
   end
 
   def duplicates
-    existing_filesets
+    existing_filesets.empty? ? [] : [GenericWork.find(existing_filesets.first.parent.id)]
   end
 
   private

--- a/app/views/error/unauthorized.html.erb
+++ b/app/views/error/unauthorized.html.erb
@@ -1,0 +1,15 @@
+<div class="alert alert-danger">
+  <%= presenter.message %>
+</div>
+<div class="row">
+  <div class="col-xs-12">
+    <div class="col-xs-3">
+      <%= image_tag("#{presenter.thumbnail}") %>
+    </div>
+    <div class="col-xs-3">
+      <p class="unauthorized_asset_title">
+        <%= presenter.title %>
+      <p>
+    </div>
+  </div>
+</div>

--- a/spec/controllers/curation_concerns/generic_works_controller_spec.rb
+++ b/spec/controllers/curation_concerns/generic_works_controller_spec.rb
@@ -38,6 +38,7 @@ describe CurationConcerns::GenericWorksController do
       expect(response).to be_unauthorized
     end
   end
+
   describe "#destroy" do
     context "with relationships" do
       let!(:asset2) { create(:asset, user: user, title: ["Title"], pref_label: "Good Title") }

--- a/spec/controllers/sufia/uploads_controller_spec.rb
+++ b/spec/controllers/sufia/uploads_controller_spec.rb
@@ -25,7 +25,9 @@ describe Sufia::UploadsController do
         let(:duplicate_file) { create(:file_set) }
         let(:duplicates)     { [duplicate_file] }
 
-        before { parent.members << duplicate_file }
+        before do
+          parent.members << duplicate_file
+        end
 
         it "reports the error" do
           expect(response).to be_success

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -22,7 +22,7 @@ describe "Searching" do
         expect(page).not_to have_link(department_asset)
       end
       visit(polymorphic_path(department_asset))
-      expect(page).to have_content("The page you have tried to access is private")
+      expect(page).to have_content("You are not authorized to see this asset. Please contact First User if you would like to request access to it.")
 
       # Searching on uid
       visit(root_path)

--- a/spec/presenters/unauthorized_presenter_spec.rb
+++ b/spec/presenters/unauthorized_presenter_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe UnauthorizedPresenter do
+  let(:id) { "1234" }
+  let(:asset) { build(:department_asset, id: "1234", pref_label: "Sample Label") }
+  let(:solr_document) { SolrDocument.new(asset.to_solr) }
+  let(:depositor) { build(:aic_user) }
+  let(:presenter)     { described_class.new(id) }
+  subject { presenter }
+
+  it "will get minimum info from the requested asset" do
+    allow(GenericWork).to receive(:find).with(id).and_return(asset)
+    allow(asset).to receive(:aic_depositor).and_return(depositor)
+
+    expect(subject.title).to eq("Sample Label")
+    expect(subject.depositor).to eq("Joe Bob")
+    expect(subject.thumbnail).to eq("/assets/work-ff055336041c3f7d310ad69109eda4a887b16ec501f35afc0a547c4adb97ee72.png")
+    expect(subject.message).to eq("You are not authorized to see this asset. Please contact Joe Bob if you would like to request access to it.")
+  end
+end

--- a/spec/services/duplicate_upload_verification_service_spec.rb
+++ b/spec/services/duplicate_upload_verification_service_spec.rb
@@ -16,8 +16,12 @@ describe DuplicateUploadVerificationService do
   end
 
   context "when duplicates exist" do
+    let(:asset) { create(:asset) }
     let(:duplicate_file) { double }
-    before { allow(FileSet).to receive(:where).with(digest_ssim: file_digest).and_return([duplicate_file]) }
-    it { is_expected.to contain_exactly(duplicate_file) }
+    before do
+      allow(duplicate_file).to receive(:parent).and_return(asset)
+      allow(FileSet).to receive(:where).with(digest_ssim: file_digest).and_return([duplicate_file])
+    end
+    it { is_expected.to contain_exactly(asset) }
   end
 end

--- a/spec/views/error/unauthorized.html.erb_spec.rb
+++ b/spec/views/error/unauthorized.html.erb_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'error/unauthorized.html.erb', type: :view do
+  let(:presenter) { double }
+  let(:page) { Capybara::Node::Simple.new(rendered) }
+  before do
+    allow(presenter).to receive(:title).and_return("Sample Work")
+    allow(presenter).to receive(:thumbnail).and_return("http://path.png")
+    allow(presenter).to receive(:message).and_return("You are not authorized to see this asset")
+    allow(presenter).to receive(:depositor).and_return("Joe Bob")
+    render template: 'error/unauthorized.html.erb', locals: { presenter: presenter }
+  end
+
+  specify do
+    expect(page).to have_selector('.alert-danger', text: "You are not authorized to see this asset")
+  end
+end


### PR DESCRIPTION
Hi @awead, this is more like what we discussed yesterday, it uses a presenter class (yay!) and no longer rescues the error, so the controller and controller tests are more simple. I decided to just handle generic_work authorization for now, although @scossu is also interested in having an unauthorized page for all situations and I could continue with that next week. The presenter class could use refactoring and there could be more assertions in the tests, but I wanted to get this out this afternoon. 

Also I'm suddenly having fedora problems running the entire test suite so couldn't check to see if everything passes, but I know the new ones for this code do.