### PR TITLE
adding create lab work button to asset show view

### DIFF
--- a/app/presenters/work_presenter.rb
+++ b/app/presenters/work_presenter.rb
@@ -18,7 +18,8 @@ class WorkPresenter < Sufia::WorkShowPresenter
       :place_of_origin,
       :provenance_text,
       :publication_history,
-      :publ_ver_level
+      :publ_ver_level,
+      :imaging_uid
     ]
   end
 

--- a/app/views/curation_concerns/base/_member.html.erb
+++ b/app/views/curation_concerns/base/_member.html.erb
@@ -14,4 +14,3 @@
     <%= render 'actions', member: member %>
   </td>
 </tr>
-

--- a/app/views/curation_concerns/base/_show_actions.html.erb
+++ b/app/views/curation_concerns/base/_show_actions.html.erb
@@ -6,4 +6,7 @@
       <%= link_to "Edit", edit_polymorphic_path([main_app, presenter]), class: 'btn btn-default' %>
       <%= link_to "Delete", [main_app, presenter], class: 'btn btn-danger', data: { confirm: "Delete this #{presenter.human_readable_type}?" }, method: :delete if presenter.deleteable? %>
   <% end %>
+  <% unless presenter.imaging_uid.empty? %>
+    <a href="http://phoenix.artic.edu/order/create/batch/<%= presenter.imaging_uid.first %>" class='btn btn-default'>Create Lab Work</a>
+  <% end %>
 </div>

--- a/spec/models/work_spec.rb
+++ b/spec/models/work_spec.rb
@@ -14,14 +14,14 @@ describe Work do
   describe "metadata" do
     subject { described_class.new }
     context "defined in the presenter" do
-      WorkPresenter.terms.each do |term|
+      (WorkPresenter.terms - [:imaging_uid]).each do |term|
         it { is_expected.to respond_to(term) }
       end
     end
   end
 
   describe "cardinality" do
-    (WorkPresenter.model_terms - [:artist, :department, :current_location, :dimensions_display]).each do |term|
+    (WorkPresenter.model_terms - [:artist, :department, :current_location, :dimensions_display, :imaging_uid]).each do |term|
       it "limits #{term} to a single value" do
         expect(described_class.properties[term.to_s].multiple?).to be false
       end

--- a/spec/presenters/citi_resource_presenter_spec.rb
+++ b/spec/presenters/citi_resource_presenter_spec.rb
@@ -10,7 +10,6 @@ describe CitiResourcePresenter do
 
   subject { presenter }
   it_behaves_like "a citi presenter"
-
   describe "#viewable?" do
     it { is_expected.to be_viewable }
   end

--- a/spec/presenters/work_presenter_spec.rb
+++ b/spec/presenters/work_presenter_spec.rb
@@ -12,6 +12,7 @@ describe WorkPresenter do
 
   it_behaves_like "a citi presenter"
   it_behaves_like "a citi presenter with related assets"
+  it { is_expected.to delegate_method(:imaging_uid).to(:solr_document) }
 
   describe "#artist_presenters?" do
     it { is_expected.to be_artist_presenters }

--- a/spec/views/curation_concerns/base/_items.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_items.html.erb_spec.rb
@@ -12,7 +12,7 @@ describe 'curation_concerns/base/items', verify_partial_doubles: false do
   let(:blacklight_configuration_context) do
     Blacklight::Configuration::Context.new(controller)
   end
-
+  let(:page) { Capybara::Node::Simple.new(rendered) }
   before do
     stub_template 'curation_concerns/base/_actions.html.erb' => 'Actions'
     allow(presenter).to receive(:member_presenters).and_return([member])

--- a/spec/views/curation_concerns/base/_show_actions.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_show_actions.html.erb_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe 'curation_concerns/base/_show_actions.html.erb' do
+  let(:asset) { build(:asset, id: '1234', pref_label: 'FineArt') }
+  let(:solr_doc) { SolrDocument.new(asset.to_solr) }
+  let(:presenter) { AssetPresenter.new(solr_doc, ability) }
+  let(:ability) { double }
+  let(:page) { Capybara::Node::Simple.new(rendered) }
+
+  subject { page }
+
+  describe "the create lab work button" do
+    context "the asset has an imaging number" do
+      before do
+        allow(ability).to receive(:can?).with(:edit, SolrDocument).and_return(true)
+        allow(ability).to receive(:can?).with(:delete, GenericWork).and_return(true)
+        allow(presenter).to receive('imaging_uid').and_return(["SI-1234"])
+        render 'curation_concerns/base/show_actions.html.erb', presenter: presenter
+      end
+      it { is_expected.to have_link("Create Lab Work", href: "http://phoenix.artic.edu/order/create/batch/" + presenter.imaging_uid.first.to_s) }
+    end
+
+    context "the asset does not have an imaging number" do
+      before do
+        allow(ability).to receive(:can?).with(:edit, SolrDocument).and_return(true)
+        allow(ability).to receive(:can?).with(:delete, GenericWork).and_return(true)
+        allow(presenter).to receive('imaging_uid').and_return([])
+        render 'curation_concerns/base/show_actions.html.erb', presenter: presenter
+      end
+      it { is_expected.not_to have_link("Create Lab Work", href: "http://phoenix.artic.edu/order/create/batch/" + presenter.imaging_uid.first.to_s) }
+    end
+  end
+end

--- a/spec/views/curation_concerns/base/show.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/show.html.erb_spec.rb
@@ -19,14 +19,6 @@ describe 'curation_concerns/base/show.html.erb' do
     render
   end
 
-  context "with a department asset" do
-    let(:asset)     { build(:department_asset, id: '999', pref_label: 'Department Asset') }
-    let(:presenter) { AssetPresenter.new(solr_document, ability) }
-    specify do
-      expect(page).to have_selector('span.label-warning', text: "Department")
-    end
-  end
-
   context "with a registered asset" do
     let(:asset)     { build(:registered_asset, id: '999', pref_label: 'Department Asset') }
     let(:presenter) { AssetPresenter.new(solr_document, ability) }


### PR DESCRIPTION
@awead, is it okay to add imaging_uid to the work_presenter terms, so that it delegates to solr, to use in a view? I'd expect this to be just fine but had to change to some work model tests to adjust, just wanted to be sure I did that correctly. I *think* I changed the tests to say the model shouldn't respond to this term because the presenter delegates it to solr but I'm not sure about that.