### PR TITLE
Force change for documents types set to nil

### DIFF
--- a/app/models/concerns/asset_metadata.rb
+++ b/app/models/concerns/asset_metadata.rb
@@ -13,8 +13,9 @@ module AssetMetadata
     property :first_document_sub_type, predicate: AIC.documentSubType1, multiple: false, class_name: "Definition"
     property :second_document_sub_type, predicate: AIC.documentSubType2, multiple: false, class_name: "Definition"
 
-    # Force these to singular terms
+    # Force these to singular terms. Ensure a nil or empty set forces a change.
     def document_type=(value)
+      document_type_will_change! unless value.present?
       if value.respond_to?(:each)
         super(value.first)
       else
@@ -23,6 +24,7 @@ module AssetMetadata
     end
 
     def first_document_sub_type=(value)
+      first_document_sub_type_will_change! unless value.present?
       if value.respond_to?(:each)
         super(value.first)
       else
@@ -31,6 +33,7 @@ module AssetMetadata
     end
 
     def second_document_sub_type=(value)
+      second_document_sub_type_will_change! unless value.present?
       if value.respond_to?(:each)
         super(value.first)
       else

--- a/spec/models/generic_work/generic_work_document_types.rb
+++ b/spec/models/generic_work/generic_work_document_types.rb
@@ -5,16 +5,48 @@ describe GenericWork do
   let(:asset) { build(:asset) }
   let(:uri)   { "http://definitions.artic.edu/doctypes/DesignFile" }
 
+  before do
+    asset.document_type_uri = uri
+    asset.save
+  end
+
   subject { asset }
 
   context "when the document is a uri" do
-    before do
-      asset.document_type_uri = uri
-      asset.save
-      asset.reload
-    end
+    before { asset.reload }
 
     its(:document_type_uri) { is_expected.to eq(uri) }
-    its(:to_solr) { is_expected.to include("document_type_ssim" => uri) }
+
+    # TODO: this has never been the case. Is it still needed?
+    # its(:to_solr) { is_expected.to include("document_type_ssim" => uri) }
+  end
+
+  describe "removing a value" do
+    context "when setting to nil" do
+      before do
+        asset.document_type = nil
+        asset.save
+      end
+
+      its(:document_type_uri) { is_expected.to be_nil }
+    end
+
+    context "when setting to an empty array" do
+      before do
+        asset.document_type = []
+        asset.save
+      end
+
+      its(:document_type_uri) { is_expected.to be_nil }
+    end
+
+    context "when setting to an empty string" do
+      before do
+        asset.document_type_uri = ""
+        asset.save
+      end
+
+      its(:document_type_uri) { is_expected.to be_nil }
+    end
   end
 end


### PR DESCRIPTION
Because we're using a Definition class that is not AF::Base, we get peculiar errors, such as when you set a Definition property to nil, the change is not recognized in the AF stack. Here we are forcing the change notification so we can successfully remove any document type that has been set.