### PR TITLE
adding resque-cleaner gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'jbuilder', '~> 2.6'
 gem 'jquery-rails'
 gem 'openseadragon', '0.3.0'
 gem 'resque-pool'
+gem 'resque-cleaner'
 gem 'rsolr', '~> 1.1'
 gem 'sass-rails', '~> 5.0'
 gem 'sdoc', '~> 0.4.0', group: :doc

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -505,6 +505,8 @@ GEM
       redis-namespace (~> 1.3)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
+    resque-cleaner (0.3.2)
+      resque (~> 1.0)
     resque-pool (0.6.0)
       rake
       resque (~> 1.22)
@@ -708,6 +710,7 @@ DEPENDENCIES
   poltergeist
   posix-spawn
   rails (= 4.2.7.1)
+  resque-cleaner
   resque-pool
   rsolr (~> 1.1)
   rspec-activemodel-mocks

--- a/config/resque_web.rb
+++ b/config/resque_web.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+require 'resque-cleaner'


### PR DESCRIPTION
Hi @awead, would you mind merging this before you deploy tonight? It's just a gem and a one-line config file, no code changes. The cleaner gem adds some helpful visibility from the resque admin, and we needed to regenerate the derivatives in test today, so it would be nice to have this visibility on that big job. 

Thanks, @jenlindner