### PR TITLE
adding resque cleaner and more logging

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,9 +3,9 @@
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 
 require File.expand_path('../config/application', __FILE__)
+require 'resque/tasks'
 
 Rails.application.load_tasks
-
 unless Rails.env.production?
   load File.expand_path('../tasks/dev.rake', __FILE__)
   load File.expand_path('../tasks/test.rake', __FILE__)

--- a/app/jobs/create_derivatives_job.rb
+++ b/app/jobs/create_derivatives_job.rb
@@ -10,7 +10,7 @@ class CreateDerivativesJob < ActiveJob::Base
     filename = CurationConcerns::WorkingDirectory.find_or_retrieve(file_id, file_set.id, filepath)
 
     file_set.create_derivatives(filename)
-
+    Resque.logger.info("queue running fine: #{CurationConcerns.config.ingest_queue_name}")
     # Reload from Fedora and reindex for thumbnail and extracted text
     file_set.reload
     file_set.update_index

--- a/config/initializers/resque_admin.rb
+++ b/config/initializers/resque_admin.rb
@@ -4,6 +4,5 @@ class ResqueAdmin
     # TODO: restrict to a group (see issue #4)
     current_user = request.env['warden'].user
     !current_user.blank?
-    # current_user.groups.include? 'umg/up.dlt.scholarsphere-admin'
   end
 end

--- a/config/initializers/resque_config.rb
+++ b/config/initializers/resque_config.rb
@@ -4,4 +4,5 @@ Resque.redis = Redis.new(host: config[:host], port: config[:port], thread_safe: 
 
 Resque.inline = Rails.env.test?
 Resque.redis.namespace = "#{Sufia.config.redis_namespace}:#{Rails.env}"
-Resque.logger.level = Logger::INFO
+Resque.logger = Logger.new(Rails.root.join('log', "#{Rails.env}_resque.log"))
+Resque.logger.level = Logger::DEBUG

--- a/lib/capistrano/tasks/resque.rake
+++ b/lib/capistrano/tasks/resque.rake
@@ -1,5 +1,4 @@
 namespace :resque do
-
   desc "Start resque pool workers"
   task :start do
     invoke "resque:restart"

--- a/lib/tasks/lakeshore.rake
+++ b/lib/tasks/lakeshore.rake
@@ -62,5 +62,4 @@ namespace :lakeshore do
                                                                 rows: 1000
                                                               })
   end
-
 end


### PR DESCRIPTION
hi @awead. This branch enables the cleaner tab in the resque admin, and contains a config change that has resque jobs log to the resque log, for easier debugging/control during ingests, derivatives, etc. I wanted to test it well but can't quite test the logging today, but that's not an app code change, so maybe can wait ....