### PR TITLE
Revert "Intermediate file is not required, ref #1371"

### DIFF
--- a/app/controllers/lakeshore/ingest_controller.rb
+++ b/app/controllers/lakeshore/ingest_controller.rb
@@ -34,14 +34,12 @@ module Lakeshore
       end
 
       def validate_asset_type
-        return unless intermediate_file
         return if AssetTypeVerificationService.call(intermediate_file, asset_type)
         ingest.errors.add(:intermediate_file, "is not the correct asset type")
         render json: ingest.errors.full_messages, status: :bad_request
       end
 
       def validate_duplicate_upload
-        return unless intermediate_file && check_duplicates?
         return if duplicate_upload.empty?
         ingest.errors.add(:intermediate_file, "is a duplicate of #{duplicate_upload.first}")
         render json: duplicate_error, status: :conflict

--- a/app/models/lakeshore/ingest.rb
+++ b/app/models/lakeshore/ingest.rb
@@ -7,7 +7,7 @@ module Lakeshore
                 :intermediate_file, :presevation_master_file, :legacy_file, :additional_files, :params,
                 :preferred_representation_for
 
-    validates :ingestor, :asset_type, :document_type_uri, presence: true
+    validates :ingestor, :asset_type, :document_type_uri, :intermediate_file, presence: true
 
     # @param [ActionController::Parameters] params from the controller
     def initialize(params)
@@ -119,7 +119,6 @@ module Lakeshore
       end
 
       def additional_uploads
-        return [] unless additional_files
         additional_files.values.map do |file|
           Sufia::UploadedFile.create(file: file, user: ingestor)
         end

--- a/script/ingest-api.sh
+++ b/script/ingest-api.sh
@@ -46,10 +46,3 @@ curl -u citi:password -X POST\
  -F 'content[intermediate]=@spec/fixtures/sun.png'\
  -F 'content[legacy]=@spec/fixtures/sun.png'\
  http://localhost:3000/api/ingest/StillImage
-
-curl -u citi:password -X POST\
- -F 'metadata[pref_label]=Asset without an image'\
- -F 'metadata[visibility]=authenticated'\
- -F 'metadata[document_type_uri]=http://definitions.artic.edu/doctypes/ConservationStillImage'\
- -F 'metadata[depositor]=awead'\
- http://localhost:3000/api/ingest/StillImage

--- a/spec/models/lakeshore/ingest_spec.rb
+++ b/spec/models/lakeshore/ingest_spec.rb
@@ -51,7 +51,9 @@ describe Lakeshore::Ingest do
 
     context "without the required parameters" do
       let(:params) { { asset_type: "StillImage" } }
-      its(:full_messages) { is_expected.to contain_exactly("Ingestor can't be blank", "Document type uri can't be blank") }
+      its(:full_messages) { is_expected.to contain_exactly("Ingestor can't be blank",
+                                                           "Document type uri can't be blank",
+                                                           "Intermediate file can't be blank") }
     end
 
     context "with a bad asset type" do


### PR DESCRIPTION
This reverts commit 1959218c1152163dc7babf42fb92e91bf147ede6.

This was necessary for the CITI image migration but is no longer necessary and is actually creating stray assets through Phoenix.