### PR TITLE
Enable adding shared assets to collections, ref #1681

### DIFF
--- a/app/helpers/sufia_helper.rb
+++ b/app/helpers/sufia_helper.rb
@@ -7,6 +7,7 @@ module SufiaHelper
   include CurationConcerns::MainAppHelpers
   include Sufia::BlacklightOverride
   include Sufia::SufiaHelperBehavior
+  include Sufia::DashboardHelperBehavior
 
   def visibility_options(variant)
     options = [
@@ -28,6 +29,12 @@ module SufiaHelper
     agent = AICUser.find_by_nick(key) || Department.find_by_department_key(key)
     return agent.pref_label if agent.is_a?(Department)
     AICUserPresenter.new(agent).display_name
+  end
+
+  # @return [True, False]
+  # Overrides Sufia::DashboardHelperBehavior to display either on my works or assets shared with me
+  def on_my_works?
+    (params[:controller] =~ /^my\/[works|shares]/) == 0
   end
 
   private

--- a/spec/features/dashboard_spec.rb
+++ b/spec/features/dashboard_spec.rb
@@ -2,24 +2,41 @@
 require 'rails_helper'
 
 describe "The dashboard" do
-  let(:user)  { create(:user1) }
+  let(:user1)  { create(:user1) }
+  let(:user2)  { create(:user2) }
 
-  before { sign_in(user) }
+  let!(:asset)        { create(:asset, :with_metadata) }
+  let!(:shared_asset) { create(:asset, :with_metadata, title: ["Shared asset"],
+                                                       depositor: "user2",
+                                                       edit_users: ["user1"]) }
 
-  context "with my assets" do
-    it "list assets belonging to the user" do
-      visit("/dashboard/works")
-      within("#search-form-header") do
-        expect(page).to have_link("My Assets")
-      end
+  before { sign_in(user1) }
+
+  it "displays the user's own assets and shared assets" do
+    # My Assets tab
+    visit("/dashboard/works")
+    within("#search-form-header") do
+      expect(page).to have_link("My Assets")
     end
-  end
+    expect(page).to have_link("No Relationship")
+    expect(page).to have_content(asset.pref_label.first)
+    within(".batch-info") do
+      expect(page).to have_button("Add to Collection", visible: false)
+    end
+    check("check_all")
+    within(".batch-info") do
+      expect(page).to have_button("Add to Collection")
+    end
 
-  context "with an asset the user has created" do
-    let!(:asset) { create(:asset, :with_metadata) }
-    it "creates a No Relationship Facet" do
-      visit("/dashboard/works")
-      expect(page).to have_link("No Relationship")
+    # Assets Shared with Me tab
+    visit("/dashboard/shares")
+    expect(page).to have_content(shared_asset.pref_label.first)
+    within(".batch-info") do
+      expect(page).to have_button("Add to Collection", visible: false)
+    end
+    check("check_all")
+    within(".batch-info") do
+      expect(page).to have_button("Add to Collection")
     end
   end
 end

--- a/spec/helpers/sufia_helper_spec.rb
+++ b/spec/helpers/sufia_helper_spec.rb
@@ -25,4 +25,23 @@ describe SufiaHelper do
       it { is_expected.to eq("First User (user1)") }
     end
   end
+
+  describe "#on_my_works?" do
+    subject { helper.on_my_works? }
+
+    context "when on my assets" do
+      before { controller.params[:controller] = "my/works" }
+      it { is_expected.to be_truthy }
+    end
+
+    context "when on assets shared with me" do
+      before { controller.params[:controller] = "my/shared" }
+      it { is_expected.to be_truthy }
+    end
+
+    context "when on my collections" do
+      before { controller.params[:controller] = "my/collections" }
+      it { is_expected.to be_falsey }
+    end
+  end
 end


### PR DESCRIPTION
Users were not able to add assets that were shared with them to collections.

This enables the "Add to Collections" button to appear in the same way that it does for assets the user owns.