### PR TITLE
Revert "Revert "Restrict batch edit to admin users, #1992""

### DIFF
--- a/app/controllers/batch_edits_controller.rb
+++ b/app/controllers/batch_edits_controller.rb
@@ -5,6 +5,8 @@ class BatchEditsController < ApplicationController
   include Sufia::BatchEditsControllerBehavior
   include AICAssetAfterDeleteBehavior
 
+  before_action :deny_non_admins
+
   # @note Overrides Sufia to pass current_ability to form instead of current_user
   def edit
     super
@@ -41,6 +43,12 @@ class BatchEditsController < ApplicationController
   # I don't know how this happening, so I'm cheating and just lopping them off here.
   def batch
     super.map { |id| id.split(/#/).first }
+  end
+
+  def deny_non_admins
+    return if current_user.admin?
+    flash[:warning] = "Batch edit is only permitted to administrators"
+    redirect_to(sufia.dashboard_works_path)
   end
 
   protected

--- a/app/views/my/_sort_and_per_page.html.erb
+++ b/app/views/my/_sort_and_per_page.html.erb
@@ -1,0 +1,43 @@
+<%# Override Sufia to display batch edit button to admin users only %>
+<div class="batch-info">
+  <div>
+    <%= render 'collections/form_for_select_collection', user_collections: @user_collections %>
+  </div>
+
+  <% if on_my_works? %>
+    <div class="batch-toggle">
+      <% session[:batch_edit_state] = "on" %>
+      <div class="button_to-inline">
+        <%= batch_edit_continue "Edit Selected" if current_user.admin? %>
+      </div>
+      <%= batch_delete %>
+      <%= button_tag "Add to Collection", class: 'btn btn-primary submits-batches submits-batches-add',
+          data: { toggle: "modal", target: "#collection-list-container" } %>
+    </div>
+  <% end %>
+
+  <div class="sort-toggle">
+    <% if @response.response['numFound'] > 1 && !sort_fields.empty? %>
+      <%= form_tag search_action_for_dashboard, method: :get, class: 'per_page form-inline' do %>
+            <div class="form-group">
+              <fieldset class="col-xs-12">
+                <legend class="sr-only"><%= t('sufia.sort_label') %></legend>
+                <%= label_tag(:sort, "<span>Sort By:</span>".html_safe) %>
+                <%= select_tag(:sort, options_for_select(sort_fields, h(params[:sort]))) %>
+                <%= label_tag :per_page do %>
+                    Show <%= select_tag :per_page, options_for_select(['10', '20', '50', '100'], h(params[:per_page])),
+                                        title: "Number of results to display per page" %> per page
+                <% end %>
+                <%= render_hash_as_hidden_fields(search_state.params_for_search.except(:per_page, :sort, :utf8)) %>
+                &nbsp;&nbsp;&nbsp;
+                <button class="btn btn-info" id="dashboard_sort_submit"><span class="glyphicon glyphicon-refresh"></span>
+                  Refresh
+                </button>
+              </fieldset>
+            </div>
+
+      <% end %>
+    <% end %>
+  </div>
+
+</div>

--- a/spec/controllers/batch_edits_controller_spec.rb
+++ b/spec/controllers/batch_edits_controller_spec.rb
@@ -2,14 +2,14 @@
 require 'rails_helper'
 
 describe BatchEditsController do
-  include_context "authenticated saml user"
-
   describe "#form_class" do
     subject { described_class.new }
     its(:form_class) { is_expected.to eq(BatchEditForm) }
   end
 
   describe "#destroy" do
+    include_context "authenticated admin user"
+
     let(:destroy_params) do
       {
         method: "delete",
@@ -41,6 +41,8 @@ describe BatchEditsController do
   end
 
   describe "#update" do
+    include_context "authenticated admin user"
+
     let(:work1) { create(:department_asset) }
     let(:work2) { create(:department_asset) }
     let(:work3) { create(:registered_asset) }
@@ -169,20 +171,21 @@ describe BatchEditsController do
   end
 
   describe "#edit" do
-    context "with an unknown id" do
+    include_context "authenticated saml user"
+
+    context "with a bogus-id" do
       it "redirects to the user's dashboard" do
         get :edit, batch_document_ids: ["bogus-id"]
         expect(response).to be_not_found
       end
     end
 
-    context "when the user does not have edit access" do
-      let(:other) { create(:user2) }
-      let(:work1) { create(:department_asset, user: other) }
+    context "with a non-admin user" do
+      let(:work1) { create(:department_asset) }
 
       it "redirects to the user's dashboard" do
         get :edit, batch_document_ids: [work1.id]
-        expect(flash[:notice]).to eq("You do not have permission to edit the documents: #{work1.id}")
+        expect(flash[:warning]).to eq("Batch edit is only permitted to administrators")
         expect(response).to be_redirect
       end
     end

--- a/spec/features/batch_edit_spec.rb
+++ b/spec/features/batch_edit_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 describe "Batch management of works", type: :feature do
   include BatchEditActions
 
-  let(:current_user) { create(:user1) }
+  let(:current_user) { create(:admin) }
   let!(:asset1)      { create(:asset, :with_metadata, pref_label: "Batch Asset 1") }
   let!(:asset2)      { create(:asset, :with_metadata, pref_label: "Batch Asset 2") }
 
@@ -12,7 +12,7 @@ describe "Batch management of works", type: :feature do
 
   before do
     sign_in_with_named_js(:batch_edit, current_user, disable_animations: true)
-    visit "/dashboard/works"
+    visit "/dashboard/shares"
   end
 
   context "when editing and viewing multiple works" do
@@ -49,7 +49,7 @@ describe "Batch management of works", type: :feature do
       expect(page).to have_content("Changes will be applied to the following 2 assets:")
       expect(page).to have_field("Language", with: asset1.language.first)
       expect(page).to have_field("Publisher", with: asset1.publisher.first)
-      expect(page).to have_select("Publish Channels", disabled: true)
+      expect(page).to have_select("Publish Channels", disabled: false)
       expect(page).to have_select("Status", selected: "Active")
     end
   end

--- a/spec/views/my/_sort_and_per_page.html.erb_spec.rb
+++ b/spec/views/my/_sort_and_per_page.html.erb_spec.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "my/sort_and_per_page.html.erb" do
+  let(:mock_response) { { "numFound" => 1 } }
+
+  before do
+    assign(:response, double(response: mock_response))
+    allow(view).to receive(:on_my_works?).and_return(true)
+    allow(view).to receive(:current_user).and_return(user)
+    render "my/sort_and_per_page"
+  end
+
+  context "with an admin user" do
+    let(:user) { create(:admin) }
+    it "renders the batch edit button" do
+      expect(rendered).to have_selector("#batch-edit")
+    end
+  end
+
+  context "with a non-admin user" do
+    let(:user) { create(:user1) }
+    it "does not render the batch edit button" do
+      expect(rendered).not_to have_selector("#batch-edit")
+    end
+  end
+end


### PR DESCRIPTION
This reverts commit 7d597e72d318c9b296d11eebe3ead4edacc70873.

Reverts it back to the original intention of allowing batch edits for
admins only.