### PR TITLE
Correct Fedora URIs from Solr

### DIFF
--- a/app/models/concerns/solr_document_extensions.rb
+++ b/app/models/concerns/solr_document_extensions.rb
@@ -27,7 +27,7 @@ module SolrDocumentExtensions
   end
 
   def fedora_uri
-    Array(self[Solrizer.solr_name('fedora_uri', :symbol)]).first
+    corrected_uri(Array(self[Solrizer.solr_name('fedora_uri', :symbol)]).first)
   end
 
   def aic_depositor
@@ -106,4 +106,11 @@ module SolrDocumentExtensions
   def related_image_id
     Array(self["hasRelatedImage_ssim"]).first
   end
+
+  private
+
+    def corrected_uri(uri)
+      return uri if URI(uri).hostname == URI(ActiveFedora.config.credentials[:url]).hostname
+      URI.join(ActiveFedora.config.credentials[:url], URI(uri).path).to_s
+    end
 end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -60,11 +60,34 @@ describe SolrDocument do
     its(:type) { is_expected.to include(AICType.Resource) }
   end
 
+  describe "#fedora_uri" do
+    let(:good_uri) do
+      URI.join(ActiveFedora.config.credentials[:url],
+               ActiveFedora.config.credentials[:base_path],
+               "id").to_s
+    end
+
+    let(:bad_uri) do
+      URI.join("https://bad.example.com/rest",
+               ActiveFedora.config.credentials[:base_path],
+               "id").to_s
+    end
+
+    context "when the FQDN matches the configured Fedora instance" do
+      subject { described_class.new(Solrizer.solr_name('fedora_uri', :symbol) => good_uri) }
+      its(:fedora_uri) { is_expected.to eq(good_uri) }
+    end
+
+    context "when the FQDN does not match the configured Fedora instance" do
+      subject { described_class.new(Solrizer.solr_name('fedora_uri', :symbol) => bad_uri) }
+      its(:fedora_uri) { is_expected.to eq(good_uri) }
+    end
+  end
+
   it { is_expected.to respond_to(:citi_uid) }
   it { is_expected.to respond_to(:uid) }
   it { is_expected.to respond_to(:id) }
   it { is_expected.to respond_to(:status) }
-  it { is_expected.to respond_to(:fedora_uri) }
   it { is_expected.to respond_to(:document_ids) }
   it { is_expected.to respond_to(:representation_ids) }
   it { is_expected.to respond_to(:preferred_representation_id) }


### PR DESCRIPTION
When Solr indexes are duplicated across environments, the Fedora uris
are indexed using the original FQDN, which may be incorrect in the new
environment.

Instead of re-indexing any assets that may have incorrect Fedora uris,
we change them to reflect the current FQDN of the configured Fedora
instance.