### PR TITLE
Refactor InboundRelationshipManagementService to use actor, ref #2042

### DIFF
--- a/app/actors/add_to_citi_resource_actor.rb
+++ b/app/actors/add_to_citi_resource_actor.rb
@@ -64,8 +64,10 @@ class AddToCitiResourceActor < CurationConcerns::Actors::AbstractActor
 
   private
 
+    # @todo wrap this in an async job? If the list of ids is very long, these updates will be done
+    #       synchronously and would impact UX.
     def add_relationships
-      management_service.add_or_remove(:representations, representation_ids)
+      management_service.add_or_remove_representations(representation_ids)
       management_service.add_or_remove(:documents, document_ids)
       management_service.add_or_remove(:attachments, attachment_uris)
       management_service.update(:preferred_representations, preferred_representation_ids)
@@ -73,6 +75,6 @@ class AddToCitiResourceActor < CurationConcerns::Actors::AbstractActor
     end
 
     def management_service
-      @management_service ||= InboundRelationshipManagementService.new(curation_concern)
+      @management_service ||= InboundRelationshipManagementService.new(curation_concern, user)
     end
 end

--- a/spec/services/inbound_relationship_management_service_spec.rb
+++ b/spec/services/inbound_relationship_management_service_spec.rb
@@ -2,46 +2,59 @@
 require 'rails_helper'
 
 describe InboundRelationshipManagementService do
-  let(:service) { described_class.new(resource) }
+  let(:user)     { nil }
+  let(:service)  { described_class.new(resource, user) }
+  let(:resource) { create(:asset) }
+  let(:work)     { create(:non_asset) }
+
+  before do
+    Rails.application.routes.draw do
+      namespace :curation_concerns, path: :concern do
+        resources :non_assets
+        mount Sufia::Engine => '/'
+      end
+    end
+  end
+
+  after do
+    Rails.application.reload_routes!
+  end
+
+  subject { work }
 
   describe "#add_or_remove" do
     context "without pre-existing relationships" do
-      let(:resource) { create(:asset) }
-      let(:work)     { create(:work) }
-
-      subject { work }
-
       context "with an id" do
         before do
-          service.add_or_remove(:representations, [work.id])
+          service.add_or_remove(:documents, [work.id])
           work.reload
         end
 
-        its(:representations) { is_expected.to contain_exactly(resource) }
+        its(:documents) { is_expected.to contain_exactly(resource) }
       end
 
       context "with a uri" do
         before do
-          service.add_or_remove(:representations, [work.uri.to_s])
+          service.add_or_remove(:documents, [work.uri.to_s])
           work.reload
         end
 
-        its(:representations) { is_expected.to contain_exactly(resource) }
+        its(:documents) { is_expected.to contain_exactly(resource) }
       end
     end
 
     context "when replacing a relationship" do
       let!(:resource) { create(:asset) }
-      let!(:old_work) { create(:work, representation_uris: [resource.uri]) }
-      let!(:work)     { create(:work) }
+      let!(:old_work) { create(:non_asset, document_uris: [resource.uri]) }
+      let!(:work)     { create(:non_asset) }
 
       it "removes the relationship from one work and adds it to the other" do
-        expect(old_work.representations).to contain_exactly(resource)
-        service.add_or_remove(:representations, [work.id])
+        expect(old_work.documents).to contain_exactly(resource)
+        service.add_or_remove(:documents, [work.id])
         work.reload
         old_work.reload
-        expect(work.representations).to contain_exactly(resource)
-        expect(old_work.representations).to be_empty
+        expect(work.documents).to contain_exactly(resource)
+        expect(old_work.documents).to be_empty
       end
     end
 
@@ -49,6 +62,39 @@ describe InboundRelationshipManagementService do
       let(:resource) { "resource" }
       it "returns an error" do
         expect { service.add_or_remove(:preferred_representations, ["ids"]) }.to raise_error(NotImplementedError)
+      end
+    end
+  end
+
+  describe "#add_or_remove_representations" do
+    context "without any representations" do
+      let(:user)     { create(:user) }
+
+      before do
+        service.add_or_remove_representations([work.id])
+        work.reload
+      end
+
+      it "sets both the representation and preferred representation" do
+        expect(work.representations).to contain_exactly(resource)
+        expect(work.preferred_representation).to eq(resource)
+      end
+    end
+
+    context "when replacing a relationship" do
+      let!(:user)     { create(:user) }
+      let!(:resource) { create(:asset) }
+      let!(:old_work) { create(:non_asset, representation_uris: [resource.uri]) }
+      let!(:work)     { create(:non_asset) }
+
+      it "removes relationships from one work and adds them to the other" do
+        expect(old_work.representations).to contain_exactly(resource)
+        service.add_or_remove_representations([work.id])
+        work.reload
+        old_work.reload
+        expect(work.representations).to contain_exactly(resource)
+        expect(work.preferred_representation).to eq(resource)
+        expect(old_work.representations).to be_empty
       end
     end
   end
@@ -62,11 +108,6 @@ describe InboundRelationshipManagementService do
     end
 
     context "with preferred representations" do
-      let(:resource) { create(:asset) }
-      let(:work)     { create(:work) }
-
-      subject { work }
-
       before do
         service.update(:preferred_representations, [work.id])
         work.reload


### PR DESCRIPTION
When adding representations via the relationships tab of the asset's
edit page, the preferred representation was not being automatically
added if it wasn't present.

The service that manages relationships between assets and non-assets
during the asset's update and create process needed to be refactored to
use the CitiResourceActor. This actor will add a preferred
representation to a non-asset, and notify CITI accordingly.