### PR TITLE
Refactor and update abilities with visibility, ref #1858

### DIFF
--- a/app/indexers/asset_indexer.rb
+++ b/app/indexers/asset_indexer.rb
@@ -2,20 +2,17 @@
 
 class AssetIndexer < Sufia::WorkIndexer
   include IndexingBehaviors
+  include IndexesDepositors
 
   def generate_solr_document
     super.tap do |solr_doc|
       solr_doc[Solrizer.solr_name("aic_type", :facetable)] = aic_types(["Asset"])
       solr_doc[Solrizer.solr_name("representation", :facetable)] = field_builder.representations
-      solr_doc[Solrizer.solr_name("depositor_full_name", :stored_searchable)] = depositor_full_name
-      solr_doc[Solrizer.solr_name("aic_depositor", :symbol)] = object.depositor
       solr_doc[Solrizer.solr_name("fedora_uri", :symbol)] = object.uri.to_s
       solr_doc[Solrizer.solr_name("digitization_source", :stored_searchable)] = pref_label_for(:digitization_source)
       solr_doc[Solrizer.solr_name("compositing", :stored_searchable)] = pref_label_for(:compositing)
       solr_doc[Solrizer.solr_name("light_type", :stored_searchable)] = pref_label_for(:light_type)
       solr_doc[Solrizer.solr_name("status", :stored_searchable)] = pref_label_for(:status)
-      solr_doc[Solrizer.solr_name("dept_created", :stored_searchable)] = pref_label_for(:dept_created)
-      solr_doc[Solrizer.solr_name("dept_created", :facetable)] = pref_label_for(:dept_created)
       solr_doc[Solrizer.solr_name("document_types", :stored_searchable)] = document_types_display
       solr_doc[Solrizer.solr_name("document_types", :facetable)] = document_types_facet
       solr_doc[Solrizer.solr_name("publish_channels", :facetable)] = object.publish_channels.map(&:pref_label)

--- a/app/indexers/collection_indexer.rb
+++ b/app/indexers/collection_indexer.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 class CollectionIndexer < CurationConcerns::CollectionIndexer
   include IndexingBehaviors
+  include IndexesDepositors
 
   def generate_solr_document
     super.tap do |solr_doc|
-      solr_doc[Solrizer.solr_name("depositor_full_name", :stored_searchable)] = depositor_full_name
-      solr_doc[Solrizer.solr_name("aic_depositor", :symbol)] = object.depositor
-      solr_doc[Solrizer.solr_name("dept_created", :stored_searchable)] = pref_label_for(:dept_created)
-      solr_doc[Solrizer.solr_name("dept_created", :facetable)] = pref_label_for(:dept_created)
       solr_doc[Solrizer.solr_name("publish_channels", :facetable)] = object.publish_channels.map(&:pref_label)
       solr_doc[Solrizer.solr_name("publish_channels", :symbol)] = object.publish_channels.map(&:pref_label)
       solr_doc[Solrizer.solr_name("collection_type", :facetable)] = pref_label_for(:collection_type)

--- a/app/indexers/concerns/indexes_depositors.rb
+++ b/app/indexers/concerns/indexes_depositors.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module IndexesDepositors
+  include ActiveSupport::Concern
+
+  def generate_solr_document
+    super.tap do |solr_doc|
+      solr_doc[Solrizer.solr_name("depositor_full_name", :stored_searchable)] = depositor_full_name
+      solr_doc[Solrizer.solr_name("aic_depositor", :symbol)] = object.depositor
+      solr_doc[Solrizer.solr_name("dept_created", :stored_searchable)] = pref_label_for(:dept_created)
+      solr_doc[Solrizer.solr_name("dept_created", :facetable)] = pref_label_for(:dept_created)
+      solr_doc[Solrizer.solr_name("dept_created_citi_uid", :symbol)] = citi_uid_for(:dept_created)
+    end
+  end
+end

--- a/app/indexers/concerns/indexing_behaviors.rb
+++ b/app/indexers/concerns/indexing_behaviors.rb
@@ -7,6 +7,11 @@ module IndexingBehaviors
     object.send(term).pref_label
   end
 
+  def citi_uid_for(term)
+    return unless object.send(term)
+    object.send(term).citi_uid
+  end
+
   def depositor_full_name
     return unless object.aic_depositor
     return object.aic_depositor.nick unless object.aic_depositor.given_name && object.aic_depositor.family_name

--- a/app/indexers/file_set_indexer.rb
+++ b/app/indexers/file_set_indexer.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 class FileSetIndexer < CurationConcerns::FileSetIndexer
+  include IndexingBehaviors
+  include IndexesDepositors
+
   def generate_solr_document
     super.tap do |solr_doc|
       solr_doc[Solrizer.solr_name("file_size", :stored_sortable, type: :integer)] = object.file_size[0]
       solr_doc[Solrizer.solr_name("image_height", :searchable, type: :integer)] = Integer(object.height.first) if object.height.present?
       solr_doc[Solrizer.solr_name("image_width", :searchable, type: :integer)] = Integer(object.width.first) if object.width.present?
-      solr_doc[Solrizer.solr_name("aic_depositor", :symbol)] = object.depositor
       solr_doc[Solrizer.solr_name("rdf_types", :symbol)] = object.type.map(&:to_s)
     end
   end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,7 +6,9 @@ class Ability
 
   self.ability_logic += [:everyone_can_create_curation_concerns,
                          :admin_abilities,
-                         :departments_can_read_assets,
+                         :depositors_can_manage,
+                         :department_users_can_manage,
+                         :read_file_set_presenters,
                          :users_can_edit_citi_resources
                         ]
 
@@ -16,14 +18,39 @@ class Ability
     can :read, SolrDocument
   end
 
-  def departments_can_read_assets
-    can :read, GenericWork do |obj|
-      !obj.department?
+  def users_can_edit_citi_resources
+    can :edit, [Work, Exhibition, Agent, Transaction, Shipment, Place] if registered_user?
+  end
+
+  def depositors_can_manage
+    can :manage, [GenericWork, SolrDocument, FileSet] do |obj|
+      current_user.email == obj.depositor
+    end
+
+    can :manage, String do |obj|
+      test_edit(obj)
     end
   end
 
-  def users_can_edit_citi_resources
-    can :edit, [Work, Exhibition, Agent, Transaction, Shipment, Place] if registered_user?
+  def department_users_can_manage
+    can :manage, [GenericWork, FileSet] do |obj|
+      obj.dept_created.citi_uid == current_user.department if obj.dept_created
+    end
+
+    can :manage, [SolrDocument, FileSetPresenter] do |obj|
+      obj.dept_created_citi_uid == current_user.department
+    end
+
+    can :manage, String do |obj|
+      doc = ActiveFedora::SolrService.query("id:#{obj}", fl: ["dept_created_citi_uid_ssim"])
+      doc.first.fetch("dept_created_citi_uid_ssim", []).first == current_user.department unless doc.empty?
+    end
+  end
+
+  def read_file_set_presenters
+    can :read, [FileSetPresenter] do |obj|
+      test_read(obj.id)
+    end
   end
 
   # Overrides Sufia::Ability to enable updates of uploaded files

--- a/app/models/concerns/permissions/lakeshore_visibility.rb
+++ b/app/models/concerns/permissions/lakeshore_visibility.rb
@@ -34,7 +34,7 @@ module Permissions::LakeshoreVisibility
         Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
       elsif read_groups.include? Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED
         Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
-      elsif read_groups.include? PERMISSION_TEXT_VALUE_DEPARTMENT
+      elsif edit_groups.include? PERMISSION_TEXT_VALUE_DEPARTMENT
         VISIBILITY_TEXT_VALUE_DEPARTMENT
       else
         default_visibility
@@ -51,7 +51,18 @@ module Permissions::LakeshoreVisibility
     def department_visibility!
       visibility_will_change! unless visibility == VISIBILITY_TEXT_VALUE_DEPARTMENT
       remove_groups = represented_visibility - department_visibility_groups
-      set_read_groups(department_visibility_groups, remove_groups)
+      set_read_groups([], remove_groups)
+      set_edit_groups(department_visibility_groups, remove_groups)
+    end
+
+    def registered_visibility!
+      super
+      set_edit_groups([department_uid].compact, [PERMISSION_TEXT_VALUE_DEPARTMENT])
+    end
+
+    def public_visibility!
+      super
+      set_edit_groups([department_uid].compact, [PERMISSION_TEXT_VALUE_DEPARTMENT])
     end
 
     def department_visibility_groups

--- a/app/models/concerns/solr_document_extensions.rb
+++ b/app/models/concerns/solr_document_extensions.rb
@@ -42,6 +42,10 @@ module SolrDocumentExtensions
     Array(self[Solrizer.solr_name('dept_created', :stored_searchable)]).first
   end
 
+  def dept_created_citi_uid
+    Array(self[Solrizer.solr_name('dept_created_citi_uid', :symbol)]).first
+  end
+
   # Date/Time resource was modified in Fedora
   def modified_date
     date_field('system_modified')

--- a/app/presenters/file_set_presenter.rb
+++ b/app/presenters/file_set_presenter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class FileSetPresenter < Sufia::FileSetPresenter
-  delegate :rdf_types, to: :solr_document
+  delegate :rdf_types, :dept_created_citi_uid, to: :solr_document
 
   def permission_badge_class
     PermissionBadge

--- a/spec/controllers/batch_edits_controller_spec.rb
+++ b/spec/controllers/batch_edits_controller_spec.rb
@@ -117,8 +117,8 @@ describe BatchEditsController do
         expect(VisibilityCopyJob).not_to receive(:perform_later)
         expect(InheritPermissionsJob).to receive(:perform_later).twice
         put :update, parameters.as_json
-        expect(work1.reload.edit_groups).to contain_exactly("newgroop")
-        expect(work2.reload.edit_groups).to contain_exactly("newgroop")
+        expect(work1.reload.edit_groups).to include("newgroop")
+        expect(work2.reload.edit_groups).to include("newgroop")
       end
     end
 

--- a/spec/factories/collections.rb
+++ b/spec/factories/collections.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 FactoryGirl.define do
-  factory :collection do
+  factory :private_collection, class: Collection do
     transient do
       user { FactoryGirl.create(:user1) }
     end
@@ -12,15 +12,24 @@ FactoryGirl.define do
     end
 
     factory :public_collection do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+      after(:build) do |collection|
+        collection.send(:public_visibility!)
+        collection.send(:publishable!)
+      end
     end
 
     factory :registered_collection do
-      visibility Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+      after(:build) do |collection|
+        collection.send(:registered_visibility!)
+        collection.send(:unpublishable!)
+      end
     end
 
-    factory :department_collection do
-      visibility Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT
+    factory :department_collection, aliases: [:collection] do
+      after(:build) do |collection|
+        collection.send(:department_visibility!)
+        collection.send(:unpublishable!)
+      end
     end
 
     factory :named_collection do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,15 +1,20 @@
 # frozen_string_literal: true
 FactoryGirl.define do
   factory :user do
-    factory :user1 do
+    factory :user1, aliases: [:default_user] do
       email 'user1'
       department '100'
       initialize_with { User.find_or_create_by(email: 'user1') }
     end
 
-    factory :user2 do
+    factory :user2, aliases: [:different_user] do
       email 'user2'
       department '200'
+    end
+
+    factory :department_user do
+      email 'department_user'
+      department '100'
     end
 
     factory :admin do
@@ -22,7 +27,9 @@ FactoryGirl.define do
       password 'password'
     end
   end
+end
 
+FactoryGirl.define do
   factory :department do
     factory :department100 do
       pref_label "Department 100"
@@ -39,7 +46,9 @@ FactoryGirl.define do
       citi_uid   "99"
     end
   end
+end
 
+FactoryGirl.define do
   factory :aic_user, aliases: [:inactive_user], class: AICUser do
     given_name 'Joe'
     family_name 'Bob'
@@ -63,6 +72,13 @@ FactoryGirl.define do
       given_name 'Third'
       family_name 'User'
       nick 'inactiveuser'
+    end
+
+    factory :aic_department_user do
+      given_name 'Department'
+      family_name 'User'
+      nick 'department_user'
+      active
     end
 
     factory :aic_admin do

--- a/spec/features/asset_permissions_spec.rb
+++ b/spec/features/asset_permissions_spec.rb
@@ -1,0 +1,141 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "Asset permissions" do
+  before { sign_in(user) }
+
+  describe "a department asset" do
+    let!(:asset) { create(:department_asset, :with_intermediate_file_set, pref_label: "Department Visibility Asset") }
+
+    context "with another user from the same department" do
+      let(:user) { create(:department_user) }
+
+      it "allows the user to edit and delete" do
+        visit(root_path)
+        fill_in(:q, with: asset.pref_label)
+        click_button("Go")
+        within("div#search-results") { click_link(asset.pref_label) }
+        expect(page).to have_content(asset.pref_label)
+        expect(page).to have_link("Delete")
+        within(".related-files") do
+          expect(page).to have_link("Versions")
+          expect(page).to have_link("Delete")
+          expect(page).to have_link("Download")
+          first(:link, "Edit").click
+        end
+        expect(page).to have_content("Edit No Title")
+        click_link("Browse View")
+        expect(page).to have_link("Edit This File")
+        expect(page).to have_link("Delete This File")
+        visit(edit_polymorphic_path(asset))
+        expect(page).to have_content(asset.pref_label)
+      end
+    end
+
+    context "with another user outside the department" do
+      let(:user) { create(:different_user) }
+
+      it "allows the user to search, but not edit or view" do
+        visit(root_path)
+        fill_in(:q, with: asset.pref_label)
+        click_button("Go")
+        within("div#search-results") do
+          expect(page).to have_content(asset.pref_label)
+          expect(page).not_to have_link(asset.pref_label)
+        end
+        visit(polymorphic_path(asset))
+        expect(page).to have_content("You are not authorized to see this asset.")
+        visit(edit_polymorphic_path(asset))
+        expect(page).to have_content("You are not authorized to see this asset.")
+      end
+    end
+  end
+
+  describe "an AIC asset" do
+    let!(:asset) { create(:aic_asset, :with_intermediate_file_set, pref_label: "AIC Visibility Asset") }
+
+    context "with another user from the same department" do
+      let(:user) { create(:department_user) }
+
+      it "allows the user to edit and delete" do
+        visit(root_path)
+        fill_in(:q, with: asset.pref_label)
+        click_button("Go")
+        within("div#search-results") { click_link(asset.pref_label) }
+        expect(page).to have_content(asset.pref_label)
+        expect(page).to have_link("Delete")
+        within(".related-files") do
+          expect(page).to have_link("Versions")
+          expect(page).to have_link("Delete")
+          expect(page).to have_link("Download")
+          first(:link, "Edit").click
+        end
+        expect(page).to have_content("Edit No Title")
+        click_link("Browse View")
+        expect(page).to have_link("Edit This File")
+        expect(page).to have_link("Delete This File")
+        visit(edit_polymorphic_path(asset))
+        expect(page).to have_content(asset.pref_label)
+      end
+    end
+
+    context "with another user outside the department" do
+      let(:user) { create(:different_user) }
+
+      it "allows the user to search and view, but not edit" do
+        visit(root_path)
+        fill_in(:q, with: asset.pref_label)
+        click_button("Go")
+        within("div#search-results") { click_link(asset.pref_label) }
+        expect(page).to have_content(asset.pref_label)
+        expect(page).not_to have_selector("div.show_actions")
+        visit(edit_polymorphic_path(asset))
+        expect(page).to have_content("You are not authorized to see this asset.")
+      end
+    end
+  end
+
+  describe "an open access asset" do
+    let!(:asset) { create(:public_asset, :with_intermediate_file_set, pref_label: "Public Visibility Asset") }
+
+    context "with another user from the same department" do
+      let(:user) { create(:department_user) }
+
+      it "allows the user to edit and delete" do
+        visit(root_path)
+        fill_in(:q, with: asset.pref_label)
+        click_button("Go")
+        within("div#search-results") { click_link(asset.pref_label) }
+        expect(page).to have_content(asset.pref_label)
+        expect(page).to have_link("Delete")
+        within(".related-files") do
+          expect(page).to have_link("Versions")
+          expect(page).to have_link("Delete")
+          expect(page).to have_link("Download")
+          first(:link, "Edit").click
+        end
+        expect(page).to have_content("Edit No Title")
+        click_link("Browse View")
+        expect(page).to have_link("Edit This File")
+        expect(page).to have_link("Delete This File")
+        visit(edit_polymorphic_path(asset))
+        expect(page).to have_content(asset.pref_label)
+      end
+    end
+
+    context "with another user outside the department" do
+      let(:user) { create(:different_user) }
+
+      it "allows the user to search and view, but not edit" do
+        visit(root_path)
+        fill_in(:q, with: asset.pref_label)
+        click_button("Go")
+        within("div#search-results") { click_link(asset.pref_label) }
+        expect(page).to have_content(asset.pref_label)
+        expect(page).not_to have_selector("div.show_actions")
+        visit(edit_polymorphic_path(asset))
+        expect(page).to have_content("You are not authorized to see this asset.")
+      end
+    end
+  end
+end

--- a/spec/indexers/asset_indexer_spec.rb
+++ b/spec/indexers/asset_indexer_spec.rb
@@ -17,6 +17,7 @@ describe AssetIndexer do
       expect(solr_doc["dept_created_tesim"]).to eq(asset.dept_created.pref_label)
       expect(solr_doc["aic_type_sim"]).to contain_exactly("Asset", "Still Image")
       expect(solr_doc["dept_created_sim"]).to eq(asset.dept_created.pref_label)
+      expect(solr_doc["dept_created_citi_uid_ssim"]).to eq(asset.dept_created.citi_uid)
       expect(solr_doc["attachments_ssim"]).to contain_exactly(attachment.id)
       expect(solr_doc["depositor_full_name_tesim"]).to contain_exactly("First User")
       expect(solr_doc["created_dtsi"]).to eq("2016-10-30T00:00:00Z")

--- a/spec/indexers/file_set_indexer_spec.rb
+++ b/spec/indexers/file_set_indexer_spec.rb
@@ -8,6 +8,11 @@ describe FileSetIndexer do
 
     it "indexes RDF types" do
       expect(solr_doc["rdf_types_ssim"]).to include(AICType.IntermediateFileSet)
+      expect(solr_doc["aic_depositor_ssim"]).to eq(file_set.aic_depositor.nick)
+      expect(solr_doc["depositor_full_name_tesim"]).to contain_exactly("First User")
+      expect(solr_doc["dept_created_tesim"]).to eq(file_set.dept_created.pref_label)
+      expect(solr_doc["dept_created_sim"]).to eq(file_set.dept_created.pref_label)
+      expect(solr_doc["dept_created_citi_uid_ssim"]).to eq(file_set.dept_created.citi_uid)
     end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -3,56 +3,225 @@ require 'rails_helper'
 require 'cancan/matchers'
 
 describe Sufia::Ability do
-  let(:user1)    { create(:user1) }
-  let(:user2)    { create(:user2) }
-  let(:admin)    { create(:admin) }
-  let(:file)     { create(:asset) }
-  let(:solr_doc) { SolrDocument.new(file.to_solr) }
+  let(:depositor)       { create(:user1) }
+  let(:different_user)  { create(:user2) }
+  let(:admin)           { create(:admin) }
+  let(:department_user) { create(:department_user) }
 
-  context "with curation concerns" do
-    subject { Ability.new(user1) }
-    it { is_expected.to be_able_to(:create, GenericWork) }
-    it { is_expected.to be_able_to(:edit, Exhibition) }
-    it { is_expected.to be_able_to(:edit, Work) }
-    it { is_expected.to be_able_to(:edit, Place) }
-    it { is_expected.to be_able_to(:edit, Transaction) }
-    it { is_expected.to be_able_to(:edit, Shipment) }
-    it { is_expected.to be_able_to(:edit, Agent) }
-    it { is_expected.not_to be_able_to(:delete, Exhibition) }
-    it { is_expected.not_to be_able_to(:delete, Work) }
-    it { is_expected.not_to be_able_to(:delete, Place) }
-    it { is_expected.not_to be_able_to(:delete, Transaction) }
-    it { is_expected.not_to be_able_to(:delete, Shipment) }
-    it { is_expected.not_to be_able_to(:delete, Agent) }
+  subject { Ability.new(depositor) }
+
+  describe "non-assets" do
+    let(:non_asset) { create(:non_asset) }
+    let(:solr_doc)  { SolrDocument.new(non_asset.to_solr) }
+
+    context "with users" do
+      subject { Ability.new(different_user) }
+
+      it { is_expected.to be_able_to(:read, non_asset) }
+      it { is_expected.to be_able_to(:edit, non_asset) }
+      it { is_expected.to be_able_to(:read, solr_doc) }
+      it { is_expected.to be_able_to(:edit, solr_doc) }
+
+      it { is_expected.not_to be_able_to(:delete, non_asset) }
+      it { is_expected.not_to be_able_to(:create, NonAsset) }
+    end
+
+    context "with administrators" do
+      subject { Ability.new(admin) }
+
+      it { is_expected.to be_able_to(:manage, non_asset) }
+      it { is_expected.to be_able_to(:manage, NonAsset) }
+    end
   end
 
-  context "with an admin" do
-    subject { Ability.new(admin) }
-    it { is_expected.to be_able_to(:edit, file.id) }
-    it { is_expected.to be_able_to(:delete, file.id) }
-  end
+  describe "department assets" do
+    let(:asset)    { create(:department_asset) }
+    let(:file_set) { create(:department_file) }
+    let(:solr_doc) { SolrDocument.new(asset.to_solr) }
+    let(:file_doc) { SolrDocument.new(file_set.to_solr) }
+    let(:fs_pres)  { FileSetPresenter.new(file_doc, subject) }
 
-  describe "department visibility" do
-    context "when the user does not own the file" do
-      subject { Ability.new(user2) }
-      it { is_expected.not_to be_able_to(:read, file) }
+    context "with the depositor" do
+      subject { Ability.new(depositor) }
+
+      it { is_expected.to be_able_to(:create, GenericWork) }
+      it { is_expected.to be_able_to(:create, FileSet) }
+      it { is_expected.to be_able_to(:manage, asset) }
+      it { is_expected.to be_able_to(:manage, asset.id) }
+      it { is_expected.to be_able_to(:manage, file_set) }
+      it { is_expected.to be_able_to(:manage, file_set.id) }
+      it { is_expected.to be_able_to(:manage, solr_doc) }
+      it { is_expected.to be_able_to(:manage, file_doc) }
+      it { is_expected.to be_able_to(:manage, fs_pres) }
+    end
+
+    context "with a user from the same department" do
+      subject { Ability.new(department_user) }
+
+      it { is_expected.to be_able_to(:create, GenericWork) }
+      it { is_expected.to be_able_to(:create, FileSet) }
+      it { is_expected.to be_able_to(:manage, asset) }
+      it { is_expected.to be_able_to(:manage, asset.id) }
+      it { is_expected.to be_able_to(:manage, file_set) }
+      it { is_expected.to be_able_to(:manage, file_set.id) }
+      it { is_expected.to be_able_to(:manage, solr_doc) }
+      it { is_expected.to be_able_to(:manage, file_doc) }
+      it { is_expected.to be_able_to(:manage, fs_pres) }
+    end
+
+    context "with a user from a different department" do
+      subject { Ability.new(different_user) }
+
+      it { is_expected.to be_able_to(:create, GenericWork) }
+      it { is_expected.to be_able_to(:create, FileSet) }
+
+      it { is_expected.not_to be_able_to([:read, :edit, :delete], asset) }
+      it { is_expected.not_to be_able_to([:read, :edit, :delete], asset.id) }
+      it { is_expected.not_to be_able_to([:read, :edit, :delete], solr_doc) }
+      it { is_expected.not_to be_able_to([:read, :edit, :delete], file_set) }
+      it { is_expected.not_to be_able_to([:read, :edit, :delete], file_set.id) }
+      it { is_expected.not_to be_able_to([:read, :edit, :delete], file_doc) }
+      it { is_expected.not_to be_able_to([:read, :edit, :delete], fs_pres) }
     end
 
     context "with an admin" do
       subject { Ability.new(admin) }
-      it { is_expected.to be_able_to(:read, file) }
+      it { is_expected.to be_able_to(:manage, asset) }
+      it { is_expected.to be_able_to(:manage, asset.id) }
+      it { is_expected.to be_able_to(:manage, solr_doc) }
+      it { is_expected.to be_able_to(:manage, file_set) }
+      it { is_expected.to be_able_to(:manage, file_set.id) }
+      it { is_expected.to be_able_to(:manage, file_doc) }
+      it { is_expected.to be_able_to(:manage, fs_pres) }
+    end
+  end
+
+  describe "AIC assets" do
+    let(:asset)    { create(:aic_asset) }
+    let(:file_set) { create(:registered_file) }
+    let(:solr_doc) { SolrDocument.new(asset.to_solr) }
+    let(:file_doc) { SolrDocument.new(file_set.to_solr) }
+    let(:fs_pres)  { FileSetPresenter.new(file_doc, subject) }
+
+    context "with a user from the same department" do
+      subject { Ability.new(department_user) }
+
+      it { is_expected.to be_able_to(:create, GenericWork) }
+      it { is_expected.to be_able_to(:create, FileSet) }
+      it { is_expected.to be_able_to(:manage, asset) }
+      it { is_expected.to be_able_to(:manage, asset.id) }
+      it { is_expected.to be_able_to(:manage, file_set) }
+      it { is_expected.to be_able_to(:manage, file_set.id) }
+      it { is_expected.to be_able_to(:manage, solr_doc) }
+      it { is_expected.to be_able_to(:manage, file_doc) }
+      it { is_expected.to be_able_to(:manage, fs_pres) }
+    end
+
+    context "with a user from a different department" do
+      subject { Ability.new(different_user) }
+
+      it { is_expected.to be_able_to(:create, GenericWork) }
+      it { is_expected.to be_able_to(:create, FileSet) }
+      it { is_expected.to be_able_to(:read, asset) }
+      it { is_expected.to be_able_to(:read, file_set) }
       it { is_expected.to be_able_to(:read, solr_doc) }
+      it { is_expected.to be_able_to(:read, file_doc) }
+      it { is_expected.to be_able_to(:read, fs_pres) }
+
+      it { is_expected.not_to be_able_to([:edit, :delete], asset) }
+      it { is_expected.not_to be_able_to([:edit, :delete], solr_doc) }
+      it { is_expected.not_to be_able_to([:edit, :delete], file_set) }
+      it { is_expected.not_to be_able_to([:edit, :delete], file_doc) }
+      it { is_expected.not_to be_able_to([:edit, :delete], fs_pres) }
+    end
+
+    context "with an admin" do
+      subject { Ability.new(admin) }
+      it { is_expected.to be_able_to(:manage, asset) }
+      it { is_expected.to be_able_to(:manage, solr_doc) }
+      it { is_expected.to be_able_to(:manage, file_set) }
+      it { is_expected.to be_able_to(:manage, file_doc) }
+      it { is_expected.to be_able_to(:manage, fs_pres) }
+    end
+  end
+
+  describe "public assets" do
+    let(:asset)    { create(:public_asset) }
+    let(:file_set) { create(:public_file) }
+    let(:solr_doc) { SolrDocument.new(asset.to_solr) }
+    let(:file_doc) { SolrDocument.new(file_set.to_solr) }
+    let(:fs_pres)  { FileSetPresenter.new(file_doc, subject) }
+
+    context "with a user from the same department" do
+      subject { Ability.new(department_user) }
+
+      it { is_expected.to be_able_to(:create, GenericWork) }
+      it { is_expected.to be_able_to(:create, FileSet) }
+      it { is_expected.to be_able_to(:manage, asset) }
+      it { is_expected.to be_able_to(:manage, asset.id) }
+      it { is_expected.to be_able_to(:manage, file_set) }
+      it { is_expected.to be_able_to(:manage, file_set.id) }
+      it { is_expected.to be_able_to(:manage, solr_doc) }
+      it { is_expected.to be_able_to(:manage, file_doc) }
+      it { is_expected.to be_able_to(:manage, fs_pres) }
+    end
+
+    context "with a user from a different department" do
+      subject { Ability.new(different_user) }
+
+      it { is_expected.to be_able_to(:create, GenericWork) }
+      it { is_expected.to be_able_to(:create, FileSet) }
+      it { is_expected.to be_able_to(:read, asset) }
+      it { is_expected.to be_able_to(:read, file_set) }
+      it { is_expected.to be_able_to(:read, solr_doc) }
+      it { is_expected.to be_able_to(:read, file_doc) }
+      it { is_expected.to be_able_to(:read, fs_pres) }
+
+      it { is_expected.not_to be_able_to([:edit, :delete], asset) }
+      it { is_expected.not_to be_able_to([:edit, :delete], solr_doc) }
+      it { is_expected.not_to be_able_to([:edit, :delete], file_set) }
+      it { is_expected.not_to be_able_to([:edit, :delete], file_doc) }
+      it { is_expected.not_to be_able_to([:edit, :delete], fs_pres) }
+    end
+
+    context "with an admin" do
+      subject { Ability.new(admin) }
+      it { is_expected.to be_able_to(:manage, asset) }
+      it { is_expected.to be_able_to(:manage, solr_doc) }
+      it { is_expected.to be_able_to(:manage, file_set) }
+      it { is_expected.to be_able_to(:manage, file_doc) }
+      it { is_expected.to be_able_to(:manage, fs_pres) }
+    end
+  end
+
+  describe "assets with only visibility and incomplete ACLs" do
+    let(:asset)    { create(:incomplete_asset) }
+    let(:file_set) { create(:incomplete_file_set) }
+    let(:solr_doc) { SolrDocument.new(asset.to_solr) }
+    let(:file_doc) { SolrDocument.new(file_set.to_solr) }
+    let(:fs_pres)  { FileSetPresenter.new(file_doc, subject) }
+
+    context "with a user from the same department" do
+      subject { Ability.new(department_user) }
+
+      it { is_expected.to be_able_to(:manage, asset) }
+      it { is_expected.to be_able_to(:manage, asset.id) }
+      it { is_expected.to be_able_to(:manage, file_set) }
+      it { is_expected.to be_able_to(:manage, file_set.id) }
+      it { is_expected.to be_able_to(:manage, solr_doc) }
+      it { is_expected.to be_able_to(:manage, file_doc) }
+      it { is_expected.to be_able_to(:manage, fs_pres) }
     end
   end
 
   describe "List resources" do
     let(:list) { create(:list) }
     context "with a user who does not have edit access" do
-      subject { Ability.new(user1) }
+      subject { Ability.new(depositor) }
       it { is_expected.not_to be_able_to(:edit, list) }
     end
     context "with a user who does have edit access" do
-      subject { Ability.new(user2) }
+      subject { Ability.new(different_user) }
       it { is_expected.to be_able_to(:edit, list) }
     end
     context "with an admin user" do

--- a/spec/models/collection/collection_permissions_spec.rb
+++ b/spec/models/collection/collection_permissions_spec.rb
@@ -2,59 +2,60 @@
 require 'rails_helper'
 
 describe Collection do
-  let(:department_asset) { build(:department_collection) }
-  let(:registered_asset) { build(:registered_collection) }
+  subject { collection }
 
-  context "by default" do
+  context "with a private collection" do
+    let(:collection) { build(:private_collection) }
     it { is_expected.to be_private }
     its(:discover_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
-    its(:visibility) { is_expected.to eq("restricted") }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE) }
   end
 
-  context "when setting to private" do
-    before { subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
-    it { is_expected.to be_private }
-  end
-
-  context "when setting to department" do
-    before { subject.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT }
-    its(:visibility) { is_expected.to eq("department") }
+  context "with a department collection" do
+    let(:collection) { build(:department_collection) }
+    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
     it { is_expected.to be_department }
   end
 
-  context "when setting to open" do
-    before { subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
-    its(:read_groups) { is_expected.to include("public") }
+  context "with a registered collection" do
+    let(:collection) { build(:registered_collection) }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+    it { is_expected.to be_registered }
+  end
+
+  context "with a public collection" do
+    let(:collection) { build(:public_collection) }
+    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) }
   end
 
   context "when changing from department to registered" do
-    subject { department_asset }
-    before { department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+    let(:collection) { build(:department_collection) }
+    before { collection.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
     its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
     its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
   end
 
   context "when changing from registered to department" do
-    subject { registered_asset }
-    before { registered_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT }
-    its(:read_groups) { is_expected.to contain_exactly(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT, "100") }
+    let(:collection) { build(:registered_collection) }
+    before { collection.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT }
+    its(:edit_groups) { is_expected.to contain_exactly(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT, "100") }
     its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
   end
 
   describe "#apply_depositor_metadata" do
     context "with an AIC depositor" do
-      subject { registered_asset }
+      let(:collection) { build(:registered_collection) }
       its(:depositor) { is_expected.to eq("user1") }
       its(:aic_depositor) { is_expected.to be_kind_of(AICUser) }
       its(:dept_created) { is_expected.to be_kind_of(Department) }
       describe "#to_solr" do
-        subject { registered_asset.to_solr }
+        subject { collection.to_solr }
         it { is_expected.to include("aic_depositor_ssim" => "user1") }
       end
     end
 
     context "without an AIC depositor" do
-      subject { build(:asset, user: "nobody") }
+      subject { build(:collection, user: "nobody") }
       its(:save) { is_expected.to be false }
     end
   end

--- a/spec/models/department_spec.rb
+++ b/spec/models/department_spec.rb
@@ -2,10 +2,7 @@
 require 'rails_helper'
 
 describe Department do
-  describe "#citi_uid" do
-    subject { described_class.all.map(&:citi_uid) }
-    it { is_expected.to contain_exactly("100", "200", "99") }
-  end
+  before(:all) { LakeshoreTesting.restore }
 
   describe "::options" do
     subject { described_class.options }

--- a/spec/models/file_set/file_set_permissions_spec.rb
+++ b/spec/models/file_set/file_set_permissions_spec.rb
@@ -2,43 +2,162 @@
 require 'rails_helper'
 
 describe FileSet do
-  let(:department_asset) { build(:department_file) }
+  let(:department_asset) { build(:file_set) }
   let(:registered_asset) { build(:registered_file) }
+  let(:public_asset)     { build(:public_file) }
 
-  describe "default permissions" do
+  context "with a department asset" do
+    subject { department_asset }
     it { is_expected.not_to be_private }
     it { is_expected.to be_department }
+    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
+    its(:read_groups) { is_expected.to be_empty }
+    its(:edit_groups) { is_expected.to contain_exactly("100", Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT) }
+    its(:discover_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
   end
 
-  describe "visibility" do
-    context "by default" do
-      its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
-      its(:read_groups) { is_expected.to be_empty }
-    end
+  context "with a registered asset" do
+    subject { registered_asset }
+    it { is_expected.not_to be_private }
+    it { is_expected.to be_registered }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
+    its(:edit_groups) { is_expected.to contain_exactly("100") }
+    its(:discover_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
+  end
 
-    context "when setting to restricted" do
-      before { subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
-      specify { expect(subject.errors.messages[:visibility]).to include("cannot be restricted") }
-    end
+  context "with a public asset" do
+    subject { public_asset }
+    it { is_expected.not_to be_private }
+    it { is_expected.to be_public }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) }
+    its(:edit_groups) { is_expected.to contain_exactly("100") }
+    its(:discover_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
+  end
 
-    context "when setting to open" do
-      before { subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
-      its(:read_groups) { is_expected.to include("public") }
-    end
+  context "when changing from department to restricted" do
+    subject { department_asset }
+    before { subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+    specify { expect(subject.errors.messages[:visibility]).to include("cannot be restricted") }
+  end
 
-    context "when changing from department to registered" do
-      subject { department_asset }
-      before { department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
-      its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
-      its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
-    end
+  context "when changing from department to registered" do
+    subject { department_asset }
+    before { department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
+    its(:edit_groups) { is_expected.to contain_exactly("100") }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+  end
 
-    context "when changing from registered to department" do
-      subject { registered_asset }
-      before { registered_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT }
-      its(:read_groups) { is_expected.to contain_exactly(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT, "100") }
-      its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
+  context "when changing from department to public" do
+    subject { department_asset }
+    before { department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) }
+    its(:edit_groups) { is_expected.to contain_exactly("100") }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+  end
+
+  context "when changing from registered to department" do
+    subject { registered_asset }
+    before { registered_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT }
+    its(:read_groups) { is_expected.to be_empty }
+    its(:edit_groups) { is_expected.to contain_exactly("100", Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT) }
+    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
+  end
+
+  context "when changing from registered to public" do
+    subject { registered_asset }
+    before { registered_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) }
+    its(:edit_groups) { is_expected.to contain_exactly("100") }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+  end
+
+  context "when changing from public to registered" do
+    subject { public_asset }
+    before { public_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
+    its(:edit_groups) { is_expected.to contain_exactly("100") }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+  end
+
+  context "when changing from public to department" do
+    subject { public_asset }
+    before { public_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT }
+    its(:read_groups) { is_expected.to be_empty }
+    its(:edit_groups) { is_expected.to contain_exactly("100", Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT) }
+    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
+  end
+
+  context "when changing a registered asset with custom permissions to department" do
+    subject { registered_asset }
+    before do
+      registered_asset.read_groups += ["custom_read_group"]
+      registered_asset.read_users += ["custom_read_user"]
+      registered_asset.edit_groups += ["custom_edit_group"]
+      registered_asset.edit_users += ["custom_edit_user"]
+      registered_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT
     end
+    its(:read_groups) { is_expected.to contain_exactly("custom_read_group") }
+    its(:read_users) { is_expected.to contain_exactly("custom_read_user") }
+    its(:edit_groups) { is_expected.to contain_exactly("100",
+                                                       Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT,
+                                                       "custom_edit_group") }
+    its(:edit_users) { is_expected.to contain_exactly("custom_edit_user", "user1") }
+    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
+  end
+
+  context "when changing a public asset with custom permissions to department" do
+    subject { public_asset }
+    before do
+      public_asset.read_groups += ["custom_read_group"]
+      public_asset.read_users += ["custom_read_user"]
+      public_asset.edit_groups += ["custom_edit_group"]
+      public_asset.edit_users += ["custom_edit_user"]
+      public_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT
+    end
+    its(:read_groups) { is_expected.to contain_exactly("custom_read_group") }
+    its(:read_users) { is_expected.to contain_exactly("custom_read_user") }
+    its(:edit_groups) { is_expected.to contain_exactly("100",
+                                                       Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT,
+                                                       "custom_edit_group") }
+    its(:edit_users) { is_expected.to contain_exactly("custom_edit_user", "user1") }
+    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
+  end
+
+  context "when changing a department asset with custom permissions to registered" do
+    subject { department_asset }
+    before do
+      department_asset.read_groups += ["custom_read_group"]
+      department_asset.read_users += ["custom_read_user"]
+      department_asset.edit_groups += ["custom_edit_group"]
+      department_asset.edit_users += ["custom_edit_user"]
+      department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+    end
+    its(:read_groups) { is_expected.to contain_exactly("custom_read_group",
+                                                       Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
+    its(:read_users) { is_expected.to contain_exactly("custom_read_user") }
+    its(:edit_groups) { is_expected.to contain_exactly("100", "custom_edit_group") }
+    its(:edit_users) { is_expected.to contain_exactly("custom_edit_user", "user1") }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+  end
+
+  context "when changing a department asset with custom permissions to public" do
+    subject { department_asset }
+    before do
+      department_asset.read_groups += ["custom_read_group"]
+      department_asset.read_users += ["custom_read_user"]
+      department_asset.edit_groups += ["custom_edit_group"]
+      department_asset.edit_users += ["custom_edit_user"]
+      department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+    its(:read_groups) { is_expected.to contain_exactly("custom_read_group",
+                                                       Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) }
+    its(:read_users) { is_expected.to contain_exactly("custom_read_user") }
+    its(:edit_groups) { is_expected.to contain_exactly("100", "custom_edit_group") }
+    its(:edit_users) { is_expected.to contain_exactly("custom_edit_user", "user1") }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
   end
 
   describe "#apply_depositor_metadata" do
@@ -54,7 +173,7 @@ describe FileSet do
     end
 
     context "without an AIC depositor" do
-      subject { build(:asset, user: "nobody") }
+      subject { build(:file_set, user: "nobody") }
       its(:save) { is_expected.to be false }
     end
   end

--- a/spec/models/generic_work/generic_work_permissions_spec.rb
+++ b/spec/models/generic_work/generic_work_permissions_spec.rb
@@ -4,41 +4,173 @@ require 'rails_helper'
 describe GenericWork do
   let(:department_asset) { build(:department_asset) }
   let(:registered_asset) { build(:registered_asset) }
+  let(:public_asset)     { build(:public_asset) }
 
-  context "by default" do
+  context "with a department asset" do
+    subject { department_asset }
     it { is_expected.not_to be_private }
     it { is_expected.to be_department }
     its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
     its(:read_groups) { is_expected.to be_empty }
+    its(:edit_groups) { is_expected.to contain_exactly("100", Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT) }
     its(:discover_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
-  end
-
-  context "when setting to restricted" do
-    before { subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
-    specify { expect(subject.errors.messages[:visibility]).to include("cannot be restricted") }
     its(:publishable) { is_expected.to be(false) }
   end
 
-  context "when setting to open" do
-    before { subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
-    its(:read_groups) { is_expected.to include("public") }
+  context "with a registered asset" do
+    subject { registered_asset }
+    it { is_expected.not_to be_private }
+    it { is_expected.to be_registered }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
+    its(:edit_groups) { is_expected.to contain_exactly("100") }
+    its(:discover_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
+    its(:publishable) { is_expected.to be(false) }
+  end
+
+  context "with a public asset" do
+    subject { public_asset }
+    it { is_expected.not_to be_private }
+    it { is_expected.to be_public }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) }
+    its(:edit_groups) { is_expected.to contain_exactly("100") }
+    its(:discover_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
     its(:publishable) { is_expected.to be(true) }
+  end
+
+  context "when changing from department to restricted" do
+    subject { department_asset }
+    before { subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
+    specify { expect(subject.errors.messages[:visibility]).to include("cannot be restricted") }
   end
 
   context "when changing from department to registered" do
     subject { department_asset }
     before { department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
     its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
+    its(:edit_groups) { is_expected.to contain_exactly("100") }
     its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
     its(:publishable) { is_expected.to be(false) }
+  end
+
+  context "when changing from department to public" do
+    subject { department_asset }
+    before { department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) }
+    its(:edit_groups) { is_expected.to contain_exactly("100") }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+    its(:publishable) { is_expected.to be(true) }
   end
 
   context "when changing from registered to department" do
     subject { registered_asset }
     before { registered_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT }
-    its(:read_groups) { is_expected.to contain_exactly(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT, "100") }
+    its(:read_groups) { is_expected.to be_empty }
+    its(:edit_groups) { is_expected.to contain_exactly("100", Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT) }
     its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
     its(:publishable) { is_expected.to be(false) }
+  end
+
+  context "when changing from registered to public" do
+    subject { registered_asset }
+    before { registered_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
+    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) }
+    its(:edit_groups) { is_expected.to contain_exactly("100") }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+    its(:publishable) { is_expected.to be(true) }
+  end
+
+  context "when changing from public to registered" do
+    subject { public_asset }
+    before { public_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
+    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
+    its(:edit_groups) { is_expected.to contain_exactly("100") }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+    its(:publishable) { is_expected.to be(false) }
+  end
+
+  context "when changing from public to department" do
+    subject { public_asset }
+    before { public_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT }
+    its(:read_groups) { is_expected.to be_empty }
+    its(:edit_groups) { is_expected.to contain_exactly("100", Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT) }
+    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
+    its(:publishable) { is_expected.to be(false) }
+  end
+
+  context "when changing a registered asset with custom permissions to department" do
+    subject { registered_asset }
+    before do
+      registered_asset.read_groups += ["custom_read_group"]
+      registered_asset.read_users += ["custom_read_user"]
+      registered_asset.edit_groups += ["custom_edit_group"]
+      registered_asset.edit_users += ["custom_edit_user"]
+      registered_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT
+    end
+    its(:read_groups) { is_expected.to contain_exactly("custom_read_group") }
+    its(:read_users) { is_expected.to contain_exactly("custom_read_user") }
+    its(:edit_groups) { is_expected.to contain_exactly("100",
+                                                       Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT,
+                                                       "custom_edit_group") }
+    its(:edit_users) { is_expected.to contain_exactly("custom_edit_user", "user1") }
+    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
+    its(:publishable) { is_expected.to be(false) }
+  end
+
+  context "when changing a public asset with custom permissions to department" do
+    subject { public_asset }
+    before do
+      public_asset.read_groups += ["custom_read_group"]
+      public_asset.read_users += ["custom_read_user"]
+      public_asset.edit_groups += ["custom_edit_group"]
+      public_asset.edit_users += ["custom_edit_user"]
+      public_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT
+    end
+    its(:read_groups) { is_expected.to contain_exactly("custom_read_group") }
+    its(:read_users) { is_expected.to contain_exactly("custom_read_user") }
+    its(:edit_groups) { is_expected.to contain_exactly("100",
+                                                       Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT,
+                                                       "custom_edit_group") }
+    its(:edit_users) { is_expected.to contain_exactly("custom_edit_user", "user1") }
+    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
+    its(:publishable) { is_expected.to be(false) }
+  end
+
+  context "when changing a department asset with custom permissions to registered" do
+    subject { department_asset }
+    before do
+      department_asset.read_groups += ["custom_read_group"]
+      department_asset.read_users += ["custom_read_user"]
+      department_asset.edit_groups += ["custom_edit_group"]
+      department_asset.edit_users += ["custom_edit_user"]
+      department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+    end
+    its(:read_groups) { is_expected.to contain_exactly("custom_read_group",
+                                                       Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
+    its(:read_users) { is_expected.to contain_exactly("custom_read_user") }
+    its(:edit_groups) { is_expected.to contain_exactly("100", "custom_edit_group") }
+    its(:edit_users) { is_expected.to contain_exactly("custom_edit_user", "user1") }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
+    its(:publishable) { is_expected.to be(false) }
+  end
+
+  context "when changing a department asset with custom permissions to public" do
+    subject { department_asset }
+    before do
+      department_asset.read_groups += ["custom_read_group"]
+      department_asset.read_users += ["custom_read_user"]
+      department_asset.edit_groups += ["custom_edit_group"]
+      department_asset.edit_users += ["custom_edit_user"]
+      department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+    end
+    its(:read_groups) { is_expected.to contain_exactly("custom_read_group",
+                                                       Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) }
+    its(:read_users) { is_expected.to contain_exactly("custom_read_user") }
+    its(:edit_groups) { is_expected.to contain_exactly("100", "custom_edit_group") }
+    its(:edit_users) { is_expected.to contain_exactly("custom_edit_user", "user1") }
+    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+    its(:publishable) { is_expected.to be(true) }
   end
 
   describe "#apply_depositor_metadata" do

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -97,6 +97,7 @@ describe SolrDocument do
   it { is_expected.to respond_to(:aic_depositor) }
   it { is_expected.to respond_to(:depositor_full_name) }
   it { is_expected.to respond_to(:dept_created) }
+  it { is_expected.to respond_to(:dept_created_citi_uid) }
   it { is_expected.to respond_to(:thumbnail_path) }
   it { is_expected.to respond_to(:related_image_id) }
 

--- a/spec/services/iiif_authorization_service_spec.rb
+++ b/spec/services/iiif_authorization_service_spec.rb
@@ -2,20 +2,19 @@
 require 'rails_helper'
 
 RSpec.describe IIIFAuthorizationService do
-  let(:user) { create(:user) }
   let(:ability) { Ability.new(user) }
   let(:controller) { double(current_ability: ability) }
+  let(:file_set) { create(:file_set) }
   let(:service) { described_class.new(controller) }
-  let(:file_set_id) { 'mp48sc763' }
+  let(:file_set_id) { file_set.id }
   let(:image_id) { "#{file_set_id}/files/0b957460-99b4-4c31-902f-0fc23eefb972" }
   let(:image) { Riiif::Image.new(image_id) }
 
   describe "#can?" do
     context "when the user has read access to the FileSet" do
-      before { allow(ability).to receive(:test_read).with(file_set_id).and_return(true) }
+      let(:user) { create(:default_user) }
       context "info" do
         subject { service.can?(:info, image) }
-
         it { is_expected.to be true }
       end
 
@@ -26,10 +25,9 @@ RSpec.describe IIIFAuthorizationService do
     end
 
     context "when the user doesn't have read access to the FileSet" do
-      before { allow(ability).to receive(:test_read).with(file_set_id).and_return(false) }
+      let(:user) { create(:different_user) }
       context "info" do
         subject { service.can?(:info, image) }
-
         it { is_expected.to be false }
       end
 

--- a/spec/support/lakeshore_testing.rb
+++ b/spec/support/lakeshore_testing.rb
@@ -20,6 +20,7 @@ class LakeshoreTesting
       FactoryGirl.create(:aic_user1)
       FactoryGirl.create(:aic_user2)
       FactoryGirl.create(:aic_user3)
+      FactoryGirl.create(:aic_department_user)
       FactoryGirl.create(:aic_admin)
     end
 

--- a/spec/views/collections/_form.html.erb_spec.rb
+++ b/spec/views/collections/_form.html.erb_spec.rb
@@ -5,6 +5,8 @@ describe "collections/_form.html.erb" do
   let(:collection) { build(:collection) }
   let(:form)       { CollectionForm.new(collection, Ability.new(nil)) }
 
+  before(:all) { LakeshoreTesting.restore }
+
   before do
     assign(:form, form)
     stub_template 'collections/_form_metadata.html.erb' => ''

--- a/spec/views/collections/_form_permission.html.erb_spec.rb
+++ b/spec/views/collections/_form_permission.html.erb_spec.rb
@@ -17,6 +17,7 @@ describe "collections/_form_permission.html.erb" do
   before { assign(:collection, collection) }
 
   context "with a private collection" do
+    let(:collection) { build(:private_collection) }
     it { is_expected.to have_checked_field("Private") }
   end
 

--- a/spec/views/curation_concerns/base/_form.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_form.html.erb_spec.rb
@@ -13,6 +13,8 @@ describe 'curation_concerns/base/_form.html.erb' do
     assign(:form, form)
   end
 
+  before(:all) { LakeshoreTesting.restore }
+
   context "with a new asset" do
     let(:work) { GenericWork.new }
     before do

--- a/spec/views/curation_concerns/base/_form_share.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_form_share.html.erb_spec.rb
@@ -14,6 +14,8 @@ describe 'curation_concerns/base/_form_share.html.erb' do
     Capybara::Node::Simple.new(rendered)
   end
 
+  before(:all) { LakeshoreTesting.restore }
+
   before { allow(controller).to receive(:current_user).and_return(user) }
 
   context "with generic works" do


### PR DESCRIPTION
Make changes to department visibility rules and add more test coverage for assets with different visibilities.

Problems with the test suite emerged in this PR that required adding additional `LakeshoreTesting.restore` before various form tests. These ought to corrected in the future.