### PR TITLE
add new line to make formatting kick in

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Startup Solr and Fedora using the included wrappers
     bundle exec fcrepo_wrapper
 
 Once they are running, you will need to load sample users and resources
+
     bundle exec rake rails:update:bin (to get bin rails)
     bundle exec rake dev:prep
 


### PR DESCRIPTION
needed new line so that 4-space prefix formatting kicked in for rake tasks instructions.