### PR TITLE
Remove ACLs from file sets, ref #2147

### DIFF
--- a/app/jobs/acl_job.rb
+++ b/app/jobs/acl_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+# Used in conjunction with AclService to call the service asynchronously via ActiveJob.
+class AclJob < ActiveJob::Base
+  queue_as { (arguments[1] || "resolrize").to_sym }
+
+  # @param [String] id of asset
+  # @param [String] _queue name used to set the queue in ::queue_as
+  def perform(id, _queue = nil)
+    asset = ActiveFedora::Base.find(id)
+    AclService.new(asset).update
+  end
+end

--- a/app/jobs/concerns/adding_files_to_works.rb
+++ b/app/jobs/concerns/adding_files_to_works.rb
@@ -8,8 +8,8 @@ module AddingFilesToWorks
       file_set = file_set_type(uploaded_file.use_uri)
       user = User.find_by_user_key(work.depositor)
       actor = file_set_actor.new(file_set, user)
-      actor.create_metadata(work, visibility: work.visibility) do |file|
-        file.permissions_attributes = work.permissions.map(&:to_hash)
+      actor.create_metadata(work) do |file|
+        file.access_control_id = work.access_control_id
       end
 
       attach_content(actor, uploaded_file.file)

--- a/app/models/concerns/file_set_permissions.rb
+++ b/app/models/concerns/file_set_permissions.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+# Defines permissions behaviors for file sets using existing modules that are present in other classes.
+# File sets do not use their own ACLs, and instead use the ACL of its parent asset. All methods
+# related to permissions are delegated to #parent. If it is not present, a default set of permissions
+# is returned.
+module FileSetPermissions
+  extend ActiveSupport::Concern
+
+  include Permissions::WithAICDepositor
+  include Permissions::LakeshoreVisibility
+  include Permissions::Readable
+  include Permissions::Writable
+
+  # Override CurationConcerns::Permissions
+  # This avoids the "Depositor must have edit access" error message.
+  def paranoid_permissions
+    true
+  end
+
+  def visibility
+    return Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT unless parent.present?
+    parent.visibility
+  end
+
+  def discover_users
+    return [] unless parent.present?
+    parent.discover_users
+  end
+
+  def discover_groups
+    return [Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED] unless parent.present?
+    parent.discover_groups
+  end
+
+  def read_users
+    return [] unless parent.present?
+    parent.read_users
+  end
+
+  def read_groups
+    return [] unless parent.present?
+    parent.read_groups
+  end
+
+  def edit_users
+    return [depositor] unless parent.present?
+    parent.edit_users
+  end
+
+  def edit_groups
+    return [dept_created.citi_uid, Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT] unless parent.present?
+    parent.edit_groups
+  end
+end

--- a/app/models/concerns/permissions/writable.rb
+++ b/app/models/concerns/permissions/writable.rb
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
+# Use this module when we want to ensure that no resource will write any of its own ACLs to Fedora.
+# This is used specifically with non-assets, such as {CitiResource} which use their own set of
+# default permissions and do not need ACLs of their own.
 module Permissions
   module Writable
     extend ActiveSupport::Concern

--- a/app/models/file_set.rb
+++ b/app/models/file_set.rb
@@ -2,7 +2,8 @@
 class FileSet < ActiveFedora::Base
   include ::CurationConcerns::FileSetBehavior
   include Sufia::FileSetBehavior
-  include Permissions
+  include FileSetPermissions
+
   self.indexer = FileSetIndexer
 
   def create_derivatives(filename, opts = {})

--- a/app/services/acl_service.rb
+++ b/app/services/acl_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+class AclService
+  attr_reader :asset
+
+  # @param [GenericWork] asset
+  def initialize(asset)
+    @asset = asset
+  end
+
+  def update
+    asset.update_index
+    asset.file_sets.map do |fs|
+      reindex_or_update(fs)
+    end
+  end
+
+  def reindex_or_update(fs)
+    if matching_acls?(fs)
+      fs.update_index
+    else
+      update_acls(fs)
+    end
+  end
+
+  private
+
+    def matching_acls?(fs)
+      asset.access_control_id == fs.access_control_id
+    end
+
+    def update_acls(fs)
+      fs.access_control_id = asset.access_control_id
+      fs.save
+    end
+end

--- a/app/views/curation_concerns/file_sets/edit.html.erb
+++ b/app/views/curation_concerns/file_sets/edit.html.erb
@@ -1,0 +1,27 @@
+<% provide :page_title, curation_concern_page_title(curation_concern) %>
+<% provide :page_header do %>
+  <h1 class="lower">Edit <%= curation_concern %></h1>
+<% end %>
+
+<div class="row">
+  <div class="col-xs-12 col-sm-4">
+    <%= media_display curation_concern.to_presenter %>
+  </div>
+  <div class="col-xs-12 col-sm-8">
+    <ul class="nav nav-tabs" role="tablist">
+      <li id="edit_descriptions_link" class="active">
+        <a href="#descriptions_display" data-toggle="tab"><i class="fa fa-tags"></i> Descriptions</a>
+      </li>
+      <li id="edit_versioning_link">
+        <a href="#versioning_display" data-toggle="tab"><i class="fa fa-sitemap"></i> Versions</a>
+      </li>
+    </ul>
+    <div class="tab-content">
+      <div id="descriptions_display" class="tab-pane active">
+        <h2>Descriptions </h2>
+        <%= render "form" %>
+      </div>
+      <%= render "versioning", file_set: curation_concern %>
+    </div>
+  </div><!-- /.col-sm-8 -->
+</div><!-- /.row -->

--- a/spec/factories/file_sets.rb
+++ b/spec/factories/file_sets.rb
@@ -4,11 +4,11 @@ FactoryGirl.define do
     transient do
       user { FactoryGirl.create(:user1) }
       content nil
+      parent nil
     end
 
     after(:build) do |file, evaluator|
       file.apply_depositor_metadata(evaluator.user)
-      file.send(:department_visibility!)
     end
 
     after(:create) do |file, evaluator|
@@ -24,13 +24,11 @@ FactoryGirl.define do
 
       factory :registered_file do
         after(:build) do |file|
-          file.send(:registered_visibility!)
         end
       end
 
       factory :public_file do
         after(:build) do |file|
-          file.send(:public_visibility!)
         end
       end
 

--- a/spec/features/edit_asset_permissions_spec.rb
+++ b/spec/features/edit_asset_permissions_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe "Editing asset permissions" do
+  let!(:user)     { create(:default_user) }
+  let!(:other)    { create(:different_user) }
+  let!(:asset)    { create(:department_asset, :with_metadata, edit_users: [other]) }
+  let!(:file_set) { create(:intermediate_file_set, edit_users: [other]) }
+
+  before do
+    asset.ordered_members = [file_set]
+    file_set.access_control_id = asset.access_control_id
+    file_set.save
+    asset.save
+    sign_in_with_js(user)
+    visit(edit_polymorphic_path(asset))
+  end
+
+  context "when changing the visibility of an asset" do
+    it "indexes the same permissions on the file set" do
+      within("ul.nav-tabs") { click_link("Share") }
+      within("#savewidget") do
+        choose('generic_work_visibility_open')
+      end
+      click_button("Save")
+      expect(page).not_to have_content("Apply changes to contents?")
+      expect(page).to have_content(asset.pref_label.first)
+      asset.reload
+      expect(asset.file_sets.first.access_control_id).to eq(asset.access_control_id)
+      expect(asset.visibility).to eq("open")
+      expect(SolrDocument.find(asset.id).visibility).to eq("open")
+      expect(asset.file_sets.first.visibility).to eq("open")
+      expect(SolrDocument.find(asset.file_sets.first.id).visibility).to eq("open")
+    end
+  end
+
+  context "when changing the sharing of an asset" do
+    it "indexes the same permissions on the file set" do
+      within("ul.nav-tabs") { click_link("Share") }
+      find(".remove_perm").click
+      click_button("Save")
+      expect(page).not_to have_content("Apply changes to contents?")
+      expect(page).to have_content(asset.pref_label.first)
+      asset.reload
+      expect(asset.edit_users).to contain_exactly(user.user_key)
+      expect(SolrDocument.find(asset.id)["edit_access_person_ssim"]).to contain_exactly(user.user_key)
+      expect(asset.file_sets.first.edit_users).to contain_exactly(user.user_key)
+      expect(SolrDocument.find(asset.file_sets.first.id)["edit_access_person_ssim"]).to contain_exactly(user.user_key)
+    end
+  end
+end

--- a/spec/features/edit_file_set_spec.rb
+++ b/spec/features/edit_file_set_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe FileSet do
+  let!(:asset) { create(:department_asset) }
+  let!(:file)  { create(:department_file, title: ["Sample File Set"]) }
+
+  let(:user) { create(:user1) }
+
+  before do
+    asset.ordered_members = [file]
+    file.access_control_id = asset.access_control_id
+    file.save
+    asset.save
+    sign_in(user)
+    visit(edit_polymorphic_path(file))
+  end
+
+  it "renders the edit page" do
+    expect(page).to have_content("Edit Sample File Set")
+    expect(page).not_to have_selector("#permissions_display")
+    fill_in("Title", with: "Updated File Set")
+    click_button("Update Attached File")
+    expect(page).to have_content("Updated File Set")
+  end
+end

--- a/spec/jobs/acl_job_spec.rb
+++ b/spec/jobs/acl_job_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe AclJob do
+  let(:asset)        { build(:asset) }
+  let(:mock_service) { double }
+
+  before { allow(ActiveFedora::Base).to receive(:find).with("asset-id").and_return(asset) }
+
+  context "when using the default queue" do
+    let(:job) { described_class.new("asset-id") }
+
+    it "calls AclService" do
+      expect(AclService).to receive(:new).with(asset).and_return(mock_service)
+      expect(mock_service).to receive(:update)
+      job.perform_now
+    end
+  end
+
+  context "when using a custom queue" do
+    let(:job) { described_class.new("asset-id", "special") }
+
+    it "calls AclService" do
+      expect(AclService).to receive(:new).with(asset).and_return(mock_service)
+      expect(mock_service).to receive(:update)
+      expect(job.queue_name).to eq("special")
+      job.perform_now
+    end
+  end
+end

--- a/spec/jobs/attach_files_to_work_job_spec.rb
+++ b/spec/jobs/attach_files_to_work_job_spec.rb
@@ -8,7 +8,7 @@ describe AttachFilesToWorkJob do
   let(:intermediate_file) { Sufia::UploadedFile.create(file: file, user: user, use_uri: AICType.IntermediateFileSet) }
   let(:master_file)       { Sufia::UploadedFile.create(file: file, user: user, use_uri: AICType.PreservationMasterFileSet) }
   let(:plain_file)        { Sufia::UploadedFile.create(file: file, user: user) }
-  let(:asset)             { create(:asset) }
+  let(:asset)             { create(:department_asset) }
 
   context "with each of the different use files" do
     let(:types) { asset.file_sets.map(&:type).map { |set| set.map(&:to_s) }.flatten.uniq }
@@ -17,6 +17,7 @@ describe AttachFilesToWorkJob do
       described_class.perform_now(asset, [original_file, intermediate_file, master_file])
       asset.reload
       expect(types).to include(AICType.OriginalFileSet, AICType.IntermediateFileSet, AICType.PreservationMasterFileSet)
+      expect(asset.file_sets.map(&:access_control_id).uniq).to contain_exactly(asset.access_control_id)
     end
   end
 
@@ -26,6 +27,7 @@ describe AttachFilesToWorkJob do
       described_class.perform_now(asset, [plain_file])
       asset.reload
       expect(asset.file_sets.map(&:class)).to contain_exactly(FileSet)
+      expect(asset.file_sets.map(&:access_control_id)).to contain_exactly(asset.access_control_id)
     end
   end
 end

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -98,10 +98,17 @@ describe Sufia::Ability do
 
   describe "AIC assets" do
     let(:asset)    { create(:aic_asset) }
-    let(:file_set) { create(:registered_file) }
+    let(:file_set) { create(:file_set) }
     let(:solr_doc) { SolrDocument.new(asset.to_solr) }
     let(:file_doc) { SolrDocument.new(file_set.to_solr) }
     let(:fs_pres)  { FileSetPresenter.new(file_doc, subject) }
+
+    before do
+      asset.ordered_members = [file_set]
+      asset.save
+      file_set.access_control_id = asset.access_control_id
+      file_set.save
+    end
 
     context "with a user from the same department" do
       subject { Ability.new(department_user) }
@@ -147,7 +154,7 @@ describe Sufia::Ability do
 
   describe "public assets" do
     let(:asset)    { create(:public_asset) }
-    let(:file_set) { create(:public_file) }
+    let(:file_set) { create(:file_set) }
     let(:solr_doc) { SolrDocument.new(asset.to_solr) }
     let(:file_doc) { SolrDocument.new(file_set.to_solr) }
     let(:fs_pres)  { FileSetPresenter.new(file_doc, subject) }
@@ -168,6 +175,13 @@ describe Sufia::Ability do
 
     context "with a user from a different department" do
       subject { Ability.new(different_user) }
+
+      before do
+        asset.ordered_members = [file_set]
+        asset.save
+        file_set.access_control_id = asset.access_control_id
+        file_set.save
+      end
 
       it { is_expected.to be_able_to(:create, GenericWork) }
       it { is_expected.to be_able_to(:create, FileSet) }

--- a/spec/models/file_set/file_set_permissions_spec.rb
+++ b/spec/models/file_set/file_set_permissions_spec.rb
@@ -2,179 +2,100 @@
 require 'rails_helper'
 
 describe FileSet do
-  let(:department_asset) { build(:file_set) }
-  let(:registered_asset) { build(:registered_file) }
-  let(:public_asset)     { build(:public_file) }
+  let(:file_set) { build(:file_set) }
+  let(:asset) { nil }
 
-  context "with a department asset" do
-    subject { department_asset }
-    it { is_expected.not_to be_private }
-    it { is_expected.to be_department }
-    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
-    its(:read_groups) { is_expected.to be_empty }
-    its(:edit_groups) { is_expected.to contain_exactly("100", Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT) }
-    its(:discover_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
-  end
-
-  context "with a registered asset" do
-    subject { registered_asset }
-    it { is_expected.not_to be_private }
-    it { is_expected.to be_registered }
-    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
-    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
-    its(:edit_groups) { is_expected.to contain_exactly("100") }
-    its(:discover_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
-  end
-
-  context "with a public asset" do
-    subject { public_asset }
-    it { is_expected.not_to be_private }
-    it { is_expected.to be_public }
-    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
-    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) }
-    its(:edit_groups) { is_expected.to contain_exactly("100") }
-    its(:discover_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
-  end
-
-  context "when changing from department to restricted" do
-    subject { department_asset }
-    before { subject.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PRIVATE }
-    specify { expect(subject.errors.messages[:visibility]).to include("cannot be restricted") }
-  end
-
-  context "when changing from department to registered" do
-    subject { department_asset }
-    before { department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
-    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
-    its(:edit_groups) { is_expected.to contain_exactly("100") }
-    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
-  end
-
-  context "when changing from department to public" do
-    subject { department_asset }
-    before { department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
-    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) }
-    its(:edit_groups) { is_expected.to contain_exactly("100") }
-    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
-  end
-
-  context "when changing from registered to department" do
-    subject { registered_asset }
-    before { registered_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT }
-    its(:read_groups) { is_expected.to be_empty }
-    its(:edit_groups) { is_expected.to contain_exactly("100", Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT) }
-    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
-  end
-
-  context "when changing from registered to public" do
-    subject { registered_asset }
-    before { registered_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC }
-    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) }
-    its(:edit_groups) { is_expected.to contain_exactly("100") }
-    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
-  end
-
-  context "when changing from public to registered" do
-    subject { public_asset }
-    before { public_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED }
-    its(:read_groups) { is_expected.to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
-    its(:edit_groups) { is_expected.to contain_exactly("100") }
-    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
-  end
-
-  context "when changing from public to department" do
-    subject { public_asset }
-    before { public_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT }
-    its(:read_groups) { is_expected.to be_empty }
-    its(:edit_groups) { is_expected.to contain_exactly("100", Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT) }
-    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
-  end
-
-  context "when changing a registered asset with custom permissions to department" do
-    subject { registered_asset }
-    before do
-      registered_asset.read_groups += ["custom_read_group"]
-      registered_asset.read_users += ["custom_read_user"]
-      registered_asset.edit_groups += ["custom_edit_group"]
-      registered_asset.edit_users += ["custom_edit_user"]
-      registered_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT
+  before do
+    if asset.present?
+      file_set.access_control_id = asset.access_control_id
+      file_set.save
+      asset.ordered_members = [file_set]
+      asset.save
     end
-    its(:read_groups) { is_expected.to contain_exactly("custom_read_group") }
-    its(:read_users) { is_expected.to contain_exactly("custom_read_user") }
-    its(:edit_groups) { is_expected.to contain_exactly("100",
-                                                       Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT,
-                                                       "custom_edit_group") }
-    its(:edit_users) { is_expected.to contain_exactly("custom_edit_user", "user1") }
-    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
   end
 
-  context "when changing a public asset with custom permissions to department" do
-    subject { public_asset }
-    before do
-      public_asset.read_groups += ["custom_read_group"]
-      public_asset.read_users += ["custom_read_user"]
-      public_asset.edit_groups += ["custom_edit_group"]
-      public_asset.edit_users += ["custom_edit_user"]
-      public_asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT
+  context "without a containing asset" do
+    specify do
+      expect(file_set).not_to be_private
+      expect(file_set).to be_department
+      expect(file_set.visibility).to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT)
+      expect(file_set.read_groups).to be_empty
+      expect(file_set.edit_groups).to contain_exactly("100", Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT)
+      expect(file_set.discover_groups).to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED)
     end
-    its(:read_groups) { is_expected.to contain_exactly("custom_read_group") }
-    its(:read_users) { is_expected.to contain_exactly("custom_read_user") }
-    its(:edit_groups) { is_expected.to contain_exactly("100",
-                                                       Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT,
-                                                       "custom_edit_group") }
-    its(:edit_users) { is_expected.to contain_exactly("custom_edit_user", "user1") }
-    its(:visibility) { is_expected.to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT) }
   end
 
-  context "when changing a department asset with custom permissions to registered" do
-    subject { department_asset }
-    before do
-      department_asset.read_groups += ["custom_read_group"]
-      department_asset.read_users += ["custom_read_user"]
-      department_asset.edit_groups += ["custom_edit_group"]
-      department_asset.edit_users += ["custom_edit_user"]
-      department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED
+  context "in a department asset" do
+    let(:asset) { build(:department_asset) }
+
+    specify do
+      expect(file_set).not_to be_private
+      expect(file_set).to be_department
+      expect(file_set.visibility).to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT)
+      expect(file_set.read_groups).to be_empty
+      expect(file_set.edit_groups).to contain_exactly("100", Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT)
+      expect(file_set.discover_groups).to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED)
     end
-    its(:read_groups) { is_expected.to contain_exactly("custom_read_group",
-                                                       Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED) }
-    its(:read_users) { is_expected.to contain_exactly("custom_read_user") }
-    its(:edit_groups) { is_expected.to contain_exactly("100", "custom_edit_group") }
-    its(:edit_users) { is_expected.to contain_exactly("custom_edit_user", "user1") }
-    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED) }
   end
 
-  context "when changing a department asset with custom permissions to public" do
-    subject { department_asset }
-    before do
-      department_asset.read_groups += ["custom_read_group"]
-      department_asset.read_users += ["custom_read_user"]
-      department_asset.edit_groups += ["custom_edit_group"]
-      department_asset.edit_users += ["custom_edit_user"]
-      department_asset.visibility = Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC
+  context "in a registered asset" do
+    let(:asset) { build(:registered_asset) }
+
+    specify do
+      expect(file_set).not_to be_private
+      expect(file_set).to be_registered
+      expect(file_set.visibility).to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_AUTHENTICATED)
+      expect(file_set.read_groups).to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED)
+      expect(file_set.edit_groups).to contain_exactly("100")
+      expect(file_set.discover_groups).to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED)
     end
-    its(:read_groups) { is_expected.to contain_exactly("custom_read_group",
-                                                       Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC) }
-    its(:read_users) { is_expected.to contain_exactly("custom_read_user") }
-    its(:edit_groups) { is_expected.to contain_exactly("100", "custom_edit_group") }
-    its(:edit_users) { is_expected.to contain_exactly("custom_edit_user", "user1") }
-    its(:visibility) { is_expected.to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC) }
+  end
+
+  context "in a public asset" do
+    let(:asset) { build(:public_asset) }
+
+    specify do
+      expect(file_set).not_to be_private
+      expect(file_set).to be_public
+      expect(file_set.visibility).to eq(Hydra::AccessControls::AccessRight::VISIBILITY_TEXT_VALUE_PUBLIC)
+      expect(file_set.read_groups).to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_PUBLIC)
+      expect(file_set.edit_groups).to contain_exactly("100")
+      expect(file_set.discover_groups).to contain_exactly(Hydra::AccessControls::AccessRight::PERMISSION_TEXT_VALUE_AUTHENTICATED)
+    end
+  end
+
+  context "when changing the asset's permissions" do
+    let(:asset) { build(:registered_asset) }
+
+    before do
+      asset.read_groups += ["custom_read_group"]
+      asset.read_users += ["custom_read_user"]
+      asset.edit_groups += ["custom_edit_group"]
+      asset.edit_users += ["custom_edit_user"]
+      asset.visibility = Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT
+      asset.save
+    end
+
+    it "retains the same ACL" do
+      expect(file_set.access_control_id).to eq(asset.access_control_id)
+      expect(file_set.read_groups).to contain_exactly("custom_read_group")
+      expect(file_set.read_users).to contain_exactly("custom_read_user")
+      expect(file_set.edit_groups).to contain_exactly("100",
+                                                      Permissions::LakeshoreVisibility::PERMISSION_TEXT_VALUE_DEPARTMENT,
+                                                      "custom_edit_group")
+      expect(file_set.edit_users).to contain_exactly("custom_edit_user", "user1")
+      expect(file_set.visibility).to eq(Permissions::LakeshoreVisibility::VISIBILITY_TEXT_VALUE_DEPARTMENT)
+    end
   end
 
   describe "#apply_depositor_metadata" do
-    context "with an AIC depositor" do
-      subject { registered_asset }
-      its(:depositor) { is_expected.to eq("user1") }
-      its(:aic_depositor) { is_expected.to be_kind_of(AICUser) }
-      its(:dept_created) { is_expected.to be_kind_of(Department) }
-      describe "#to_solr" do
-        subject { registered_asset.to_solr }
-        it { is_expected.to include("aic_depositor_ssim" => "user1") }
-      end
-    end
-
-    context "without an AIC depositor" do
-      subject { build(:file_set, user: "nobody") }
-      its(:save) { is_expected.to be false }
+    subject { file_set }
+    its(:depositor) { is_expected.to eq("user1") }
+    its(:aic_depositor) { is_expected.to be_kind_of(AICUser) }
+    its(:dept_created) { is_expected.to be_kind_of(Department) }
+    describe "#to_solr" do
+      subject { file_set.to_solr }
+      it { is_expected.to include("aic_depositor_ssim" => "user1") }
     end
   end
 end

--- a/spec/services/acl_service_spec.rb
+++ b/spec/services/acl_service_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe AclService do
+  let(:asset)    { build(:asset) }
+  let(:file_set) { build(:file_set) }
+  let(:service)  { described_class.new(asset) }
+
+  before do
+    allow(asset).to receive(:file_sets).and_return([file_set])
+  end
+
+  describe "#update" do
+    context "when the acls do not match" do
+      it "re-indexes an assets file sets" do
+        expect(asset).to receive(:update_index)
+        expect(file_set).to receive(:update_index)
+        service.update
+        expect(file_set.access_control_id).to eq(asset.access_control_id)
+      end
+    end
+
+    context "when the acls match" do
+      before { allow(service).to receive(:matching_acls?).with(file_set).and_return(true) }
+
+      it "re-indexes an assets file sets" do
+        expect(asset).to receive(:update_index)
+        expect(file_set).to receive(:update_index)
+        expect(file_set).not_to receive(:save)
+        service.update
+      end
+    end
+  end
+end


### PR DESCRIPTION
Maintaining the permissions between asset and file set was becoming
problematic.

In order to ensure file sets always have the same permissions as their
parent assets, each file set will use the same access control resource
as the asset. This effectively means that file sets cannot have
independent permissions and will always use whatever permissions are set
on the asset.

As set of default permissions does exist, temporarily, or if for some
reason the file set has no parent. These permissions equate to
"department" level visibility.

This ticket also address several other tickets: #2112, #1495, and #1913.
Since file sets now do not have separate permissions it renders these
other tickets moot.