### PR TITLE
Enable creation of single assets, ref #1806

### DIFF
--- a/app/forms/batch_upload_form.rb
+++ b/app/forms/batch_upload_form.rb
@@ -48,11 +48,6 @@ class BatchUploadForm < Sufia::Forms::BatchUploadForm
     []
   end
 
-  # The default file set type created for each asset
-  def use_uri
-    AICType.IntermediateFileSet
-  end
-
   # Overrides hydra-editor MultiValueInput#collection
   def [](term)
     if [:imaging_uid, :view_notes].include? term

--- a/app/forms/concerns/asset_form_behaviors.rb
+++ b/app/forms/concerns/asset_form_behaviors.rb
@@ -43,5 +43,10 @@ module AssetFormBehaviors
         :batch_uid
       ]
     end
+
+    # The default file set type created for each asset
+    def use_uri
+      AICType.IntermediateFileSet
+    end
   end
 end

--- a/app/forms/curation_concerns/generic_work_form.rb
+++ b/app/forms/curation_concerns/generic_work_form.rb
@@ -28,7 +28,7 @@ module CurationConcerns
     self.required_fields = [:asset_type, :document_type_uri]
 
     def primary_terms
-      self.class.aic_terms - [:external_resources]
+      self.class.aic_terms - [:asset_type, :external_resources]
     end
 
     def secondary_terms

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -57,11 +57,21 @@ module ApplicationHelper
   end
 
   def use_uri_options
-    [
-      ["No role", nil],
-      [AICType.OriginalFileSet.label, AICType.OriginalFileSet],
-      [AICType.PreservationMasterFileSet.label, AICType.PreservationMasterFileSet],
-      [AICType.LegacyFileSet.label, AICType.LegacyFileSet]
-    ]
+    if controller_name == "generic_works"
+      default_use_uris.unshift([AICType.IntermediateFileSet.label, AICType.IntermediateFileSet])
+    else
+      default_use_uris
+    end
   end
+
+  private
+
+    def default_use_uris
+      [
+        ["No role", nil],
+        [AICType.OriginalFileSet.label, AICType.OriginalFileSet],
+        [AICType.PreservationMasterFileSet.label, AICType.PreservationMasterFileSet],
+        [AICType.LegacyFileSet.label, AICType.LegacyFileSet]
+      ]
+    end
 end

--- a/app/views/_toolbar.html.erb
+++ b/app/views/_toolbar.html.erb
@@ -32,6 +32,7 @@
             </li>
           <% end %>
           <li><%= link_to t("sufia.toolbar.works.batch"), sufia.new_batch_upload_path %></li>
+          <li><%= link_to t("sufia.toolbar.works.new"), new_polymorphic_path([main_app, GenericWork]) %></li>
         </ul>
       </li>
     <% end %>

--- a/app/views/curation_concerns/base/_form.html.erb
+++ b/app/views/curation_concerns/base/_form.html.erb
@@ -1,0 +1,19 @@
+<%= simple_form_for [main_app, @form], html: { multipart: true } do |f| %>
+<% content_for :files_tab do %>
+    <p class="instructions"><%= t("sufia.batch_uploads.files.instructions") %></p>
+    <%= render 'records/edit_fields/asset_type.html', f: f, key: :asset_type %>
+  <% end %>
+  <%= render 'curation_concerns/base/guts4form', f: f, tabs: %w[files metadata relationships share] do %>
+  <% end %>
+  <%= f.input :use_uri, as: :hidden %>
+<% end %>
+
+<%= render "sufia/batch_uploads/lakeshore_js_template" %>
+
+<script type="text/javascript">
+  Blacklight.onLoad(function() {
+    <%# This causes the page to switch back to the default template if they've
+        previously visited the batch download page in this Turbolinks session %>
+    $("#fileupload").fileupload('option', 'downloadTemplateId', 'template-download')
+  });
+</script>

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -66,6 +66,12 @@ wav_mime_type = MIME::Type.new("audio/wav") do |t|
 end
 MIME::Types.add wav_mime_type
 
+dng_mime_type = MIME::Type.new("image/x-adobe-dng") do |t|
+  t.extensions = %w(dng)
+  t.friendly("en" => "Adobe Digital Negative Raw Image file (DNG)")
+end
+MIME::Types.add dng_mime_type
+
 # Register application mime types
 Mime::Type.register 'application/x-endnote-refer', :endnote
 Mime::Type.register "application/n-triples", :nt

--- a/config/locales/sufia.en.yml
+++ b/config/locales/sufia.en.yml
@@ -29,7 +29,7 @@ en:
         shares: "Shares"
       works:
         menu: "Assets"
-        new: "New"
+        new: "Create Single Asset"
         my: "My Assets"
         batch: "Create Assets"
       collections:

--- a/lib/asset_type/still_image.rb
+++ b/lib/asset_type/still_image.rb
@@ -6,7 +6,8 @@ module AssetType
        "image/jpeg",
        "image/png",
        "image/tiff",
-       "image/jpf"]
+       "image/jpf",
+       "image/x-adobe-dng"]
     end
   end
 end

--- a/spec/features/batch_upload_spec.rb
+++ b/spec/features/batch_upload_spec.rb
@@ -13,6 +13,10 @@ describe "Batch upload" do
       visit("/batch_uploads/new")
       # Intial state of the form
       expect(tabs[1][:class]).to eq("disabled")
+      expect(tabs[0].text).to eq("Files")
+      expect(tabs[1].text).to eq("Descriptions")
+      expect(tabs[2].text).to eq("Relationships")
+      expect(tabs[3].text).to eq("Share")
       expect(page).to have_select("asset_type_select", selected: '')
       expect(page).not_to have_selector(".fileupload-buttonbar")
       expect(page).not_to have_selector(".asset-stillimage")

--- a/spec/features/edit_asset_spec.rb
+++ b/spec/features/edit_asset_spec.rb
@@ -14,6 +14,7 @@ describe "Editing assets" do
   end
 
   it "renders the form with existing values" do
+    click_link("Descriptions")
     expect(selected_document_type).to eq(asset.document_type_uri)
     expect(selected_first_document_sub_type).to eq(asset.first_document_sub_type_uri)
     expect(selected_second_document_sub_type).to eq(asset.second_document_sub_type_uri)

--- a/spec/features/new_asset_spec.rb
+++ b/spec/features/new_asset_spec.rb
@@ -11,17 +11,43 @@ describe "Creating a new asset" do
   it "enforces a workflow" do
     # Intial state of the form
     expect(tabs[1][:class]).to eq("disabled")
+    expect(tabs[0].text).to eq("Files")
+    expect(tabs[1].text).to eq("Descriptions")
+    expect(tabs[2].text).to eq("Relationships")
+    expect(tabs[3].text).to eq("Share")
     expect(page).to have_select("asset_type_select", selected: '')
-    expect(document_type_select_options.count).to eq(1)
-    expect(document_type_select_options.first.text).to eq("Please select asset type first")
+    expect(page).not_to have_selector(".fileupload-buttonbar")
+    expect(page).not_to have_selector(".asset-stillimage")
+    expect(page).not_to have_selector(".asset-text")
 
-    # Choosing the asset type enables the files tab and document type options
+    # Choosing the asset type enables the files tab and displays mime types
     select("Still Image", from: "asset_type_select")
     expect(tabs[1][:class]).not_to eq("disabled")
     expect(hidden_asset_type.value).to eq(AICType.StillImage)
-    expect(document_type_select_options.count).to eq(12)
+    expect(page).to have_selector(".fileupload-buttonbar")
+    expect(page).to have_selector(".asset-stillimage")
+    expect(page).to have_selector("li", text: "Adobe Portable Document Format")
+    expect(page).not_to have_selector(".asset-text")
+
+    # Upload a file
+    attach_file('files[]', File.join(fixture_path, "sun.png"), visible: false)
+    within("div#fileupload") do
+      sleep 0.1 until page.text.include?("sun.png")
+    end
+
+    # Add descriptions
+    click_link("Descriptions")
     select("Imaging", from: "generic_work_document_type_uri")
-    select("Event", from: "generic_work_first_document_sub_type_uri")
+    select("Event Photography", from: "generic_work_first_document_sub_type_uri")
     select("Lecture", from: "generic_work_second_document_sub_type_uri")
+    fill_in("Preferred Title", with: "The Sun")
+
+    # Save the asset, but skip characterization and derivative creation
+    expect(CharacterizeJob).to receive(:perform_later)
+    click_button("Save")
+
+    # Viewing the asset
+    expect(page).to have_content("The Sun")
+    expect(page).to have_link("sun.png")
   end
 end

--- a/spec/forms/curation_concerns/generic_work_form_spec.rb
+++ b/spec/forms/curation_concerns/generic_work_form_spec.rb
@@ -20,7 +20,7 @@ describe CurationConcerns::GenericWorkForm do
   end
 
   describe "#primary_terms" do
-    its(:primary_terms) { is_expected.not_to include(:external_resources) }
+    its(:primary_terms) { is_expected.not_to include(:asset_type, :external_resources) }
   end
 
   describe "#secondary_terms" do
@@ -29,6 +29,10 @@ describe CurationConcerns::GenericWorkForm do
 
   describe "#asset_type" do
     its(:asset_type) { is_expected.to eq(AICType.StillImage) }
+  end
+
+  describe "#use_uri" do
+    its(:use_uri) { is_expected.to eq(AICType.IntermediateFileSet) }
   end
 
   context "A Form with Alt Label metadata" do

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'rails_helper'
+
 describe ApplicationHelper do
   describe "#env_title_prefix" do
     it "returns LCL: when local environment" do
@@ -31,6 +32,19 @@ describe ApplicationHelper do
       f = stub_const("Figaro::ENV", double)
       allow(f).to receive(:LAKESHORE_ENV) { nil }
       expect(helper.env_title_prefix).to eq("")
+    end
+  end
+
+  describe "#use_uri_options" do
+    subject { helper.use_uri_options }
+
+    context "when creating in batches" do
+      it { is_expected.not_to include([AICType.IntermediateFileSet.label, AICType.IntermediateFileSet]) }
+    end
+
+    context "when creating a single asset" do
+      before { allow(helper).to receive(:controller_name).and_return("generic_works") }
+      it { is_expected.to include([AICType.IntermediateFileSet.label, AICType.IntermediateFileSet]) }
     end
   end
 end

--- a/spec/lib/asset_type/still_image_spec.rb
+++ b/spec/lib/asset_type/still_image_spec.rb
@@ -10,11 +10,20 @@ describe AssetType::StillImage do
                                         "image/jpeg",
                                         "image/png",
                                         "image/tiff",
-                                        "image/jpf")}
+                                        "image/jpf",
+                                        "image/x-adobe-dng")}
   end
 
   describe "::types" do
     subject { described_class.types }
     its(:first) { is_expected.to be_kind_of(MIME::Type) }
+  end
+
+  describe "#friendly" do
+    subject { MIME::Types[type].first.friendly }
+    context "with DNG mime types" do
+      let(:type) { "image/x-adobe-dng" }
+      it { is_expected.to eq("Adobe Digital Negative Raw Image file (DNG)") }
+    end
   end
 end

--- a/spec/services/asset_type_verification_service_spec.rb
+++ b/spec/services/asset_type_verification_service_spec.rb
@@ -7,9 +7,12 @@ describe AssetTypeVerificationService do
   describe "still images" do
     let(:asset_type) { AICType.StillImage }
 
-    context "when valid" do
-      let(:file) { double(original_filename: "good.tiff") }
-      it { is_expected.to be true }
+    context "with a valid still image" do
+      ["pdf", "jpeg", "png", "tiff", "jpf", "dng"].each do |ext|
+        it "registers the #{ext} extension" do
+          expect(described_class.call(double(original_filename: "good.#{ext}"), asset_type)).to be true
+        end
+      end
     end
 
     context "when invalid" do


### PR DESCRIPTION
Assets need to be created singly, just as they are in batches.

The UI for creating single assets is exactly the same as in batch.
The only difference being an intermediate file set may be selected.
The workflow is expanded so that an intermediate must be chosen in order
for the form to be submitted.