### PR TITLE
move dev:prep data creation to seeds.rb from factory_girl

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,31 @@
 #
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
+
+puts "environment is #{Figaro.env.lakeshore_env}"
+
+if Figaro.env.lakeshore_env == "dev"
+  sample_metadata = {
+      citi_uid: "43523",
+      creator_display: "Dolly Boojum\nAmerican, born 1275",
+      credit_line: "Gift of Mr. Dummy Lee & Mrs. Parrot Funkaroo",
+      date_display: "1995 (maybe)",
+      description: ["This is a nice painting."],
+      dimensions_display: ["1230 x 820 mm"],
+      earliest_year: "1990",
+      exhibition_history: "Group show at the Garage Gallery Association of Illinois",
+      gallery_location: "Gallery 1234",
+      inscriptions: "Signed, recto, lower right, \"XYZ\"",
+      latest_year: "1995",
+      main_ref_number: "1999.397",
+      medium_display: "Oil Painting",
+      object_type: "Painting",
+      pref_label: "The Great Sidewalk Gum",
+      provenance_text: "Picked up from a dumpster on Damen and Diversey\nOrigin unknown",
+      publ_ver_level: "0",
+      publication_history: "The Book of Best Paintings on the Block",
+      uid: "WO-43523"
+  }
+
+  Work.create(sample_metadata)
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,7 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 
+# added this when we were faced with no data in DEV env and needed to run dev:prep, but DEV is no longer run in "development"
 puts "environment is #{Figaro.env.lakeshore_env}"
 
 if Figaro.env.lakeshore_env == "dev"


### PR DESCRIPTION
LAKE DEV citi data does not exist and dev:prep uses FactoryGirl gem which isn't loaded when "production" so moving to seeds.

Will add other citi resources at some point after I'm done testing something in DEV which started this whole snowball :)