### PR TITLE
2327: change 'Resource' to 'Work' or 'Citi Work' on Work show page

### DIFF
--- a/app/views/curation_concerns/base/_add_asset.html.erb
+++ b/app/views/curation_concerns/base/_add_asset.html.erb
@@ -1,7 +1,7 @@
 <div class="dropdown">
   <button class="btn btn-default dropdown-toggle" type="button" id="add-asset-menu"
           data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-    <%= t("lakeshore.relationship.add_assets") %>
+    <%= t("lakeshore.relationship.add_assets") + presenter.solr_document["has_model_ssim"].first %>
     <span class="caret"></span>
   </button>
   <ul class="dropdown-menu" aria-labelledby="add-asset-menu">

--- a/config/locales/lakeshore.en.yml
+++ b/config/locales/lakeshore.en.yml
@@ -15,7 +15,7 @@ en:
         duplicate: "%{name} is a duplicate of:"
 
     relationship:
-      add_assets: "Add New Assets to this Resource"
+      add_assets: "Add New Assets to this CITI "
       batch_add_representations: "Add Representations"
       batch_add_documentation: "Add Documentation"
     collections:

--- a/spec/views/curation_concerns/base/_add_asset.html.erb_spec.rb
+++ b/spec/views/curation_concerns/base/_add_asset.html.erb_spec.rb
@@ -1,16 +1,22 @@
 # frozen_string_literal: true
 require 'rails_helper'
 
-describe 'curation_concerns/base/_add_asset.html.erb' do
-  let(:work)      { build(:work, id: 'work-id', citi_uid: 'work-uid') }
-  let(:user)      { create(:user1) }
-  let(:presenter) { WorkPresenter.new(SolrDocument.new(work.to_solr), user) }
-  let(:page)      { rendered }
+["work", "agent", "exhibition", "shipment", "transaction", "place"].each do |type|
+  describe 'curation_concerns/base/_add_asset.html.erb' do
+    let(:work)      { build(type.to_sym, id: type + '-id', citi_uid: type + '-uid') }
+    let(:user)      { create(:user1) }
+    let(:presenter) { (type.capitalize + "Presenter").constantize.new(SolrDocument.new(work.to_solr), user) }
+    let(:page)      { rendered }
 
-  before { render 'curation_concerns/base/add_asset.html.erb', presenter: presenter }
+    before { render 'curation_concerns/base/add_asset.html.erb', presenter: presenter }
 
-  it "renders links for creating new assets from CITI resources" do
-    expect(page).to include("/batch_uploads/new?citi_type=Work&amp;citi_uid%5B%5D=work-uid&amp;relationship=representation_for")
-    expect(page).to include("/batch_uploads/new?citi_type=Work&amp;citi_uid%5B%5D=work-uid&amp;relationship=documentation_for")
+    it "renders links for creating new assets from CITI resources" do
+      expect(page).to include("/batch_uploads/new?citi_type=#{type.capitalize}&amp;citi_uid%5B%5D=#{type}-uid&amp;relationship=representation_for")
+      expect(page).to include("/batch_uploads/new?citi_type=#{type.capitalize}&amp;citi_uid%5B%5D=#{type}-uid&amp;relationship=documentation_for")
+    end
+
+    it "has dropdown button that says 'Add New Assets to this CITI #{type.capitalize}'" do
+      expect(page).to include("Add New Assets to this CITI #{type.capitalize}")
+    end
   end
 end


### PR DESCRIPTION
* https://cits.artic.edu/redmine/issues/2327
* changed to CITI work for now until I figure out how to customize based on Work type (Agent, Exhibition etc)