### PR TITLE
2339: Replace "preferred representation" in view page with star icon

### DIFF
--- a/app/assets/javascripts/lakeshore.js
+++ b/app/assets/javascripts/lakeshore.js
@@ -82,7 +82,7 @@ $(function() {
         parent_table.prepend(current_row);
     }
 
-    $("tbody").on('click', '.fa-star-o', function(){
+    $("table.representation_uris").on('click', '.fa-star-o', function(){
         var $this = $(this)
         var current_row = $this.closest('tr');
         var parent_table = current_row.parent();

--- a/app/assets/javascripts/lakeshore/asset_manager.es6
+++ b/app/assets/javascripts/lakeshore/asset_manager.es6
@@ -14,8 +14,9 @@ export class AssetManager {
 
     $('.am-add').on('click', function(event) {
       event.preventDefault()
-      $this.data = $(this).data()
-      $('table.'+$this.data.attribute).append($this.assetRow)
+      $this.data = $(this).data();
+      var parent_div_class = $(this).closest("div").attr('class');
+      $('table.'+$this.data.attribute).append($this.assetRow(parent_div_class));
       var sel = '.' + $this.data.attribute
       $(sel).select2('val', '')
     })
@@ -45,10 +46,11 @@ export class AssetManager {
     $(row).html($(input))
   }
 
-  get assetRow() {
+  assetRow(parent_div) {
     var image_tag = this.selectedAssetImage ? '<img src="' + this.selectedAssetImage + '" />' : '';
-    var pref_rep_star = '<i class="fa fa-star-o"></i>'
-    var html =
+    var pref_rep_star = '<i class="fa fa-star-o"></i>';
+
+    var representations_html =
       '<tr>' +
         '<td>' + pref_rep_star + '</td>' +
         '<td>' + image_tag + '</td>' +
@@ -56,8 +58,22 @@ export class AssetManager {
            this.selectedAssetText + this.hiddenInput +
         '</td>' +
         '<td><a href="#" class="btn btn-danger am-delete">- Remove</a></td>' +
-      '</td>'
-    return html
+      '</td>';
+
+    var documentations_html =
+        '<tr>' +
+        '<td>' + image_tag + '</td>' +
+        '<td>' +
+        this.selectedAssetText + this.hiddenInput +
+        '</td>' +
+        '<td><a href="#" class="btn btn-danger am-delete">- Remove</a></td>' +
+        '</td>';
+
+    if (parent_div.indexOf("work_representation_uris") >= 0) {
+        return representations_html;
+    } else {
+        return documentations_html;
+    }
   }
 
   // Input inserted when a asset is selected

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,9 +23,9 @@ module ApplicationHelper
     render 'linked_attribute', attribute_doc: solr_doc, attribute_label: label
   end
 
-  def render_asset_relationship(presenters, heading)
+  def render_asset_relationship(presenters, heading, need_star = false, *args)
     return unless presenters.present?
-    render "asset_relationship", heading: heading, presenters: presenters
+    render "asset_relationship", heading: heading, presenters: presenters, need_star: need_star, pref_rep_id: args[0]
   end
 
   def render_citi_relationship(presenters, heading)
@@ -61,6 +61,14 @@ module ApplicationHelper
       default_use_uris.unshift([AICType.IntermediateFileSet.label, AICType.IntermediateFileSet])
     else
       default_use_uris
+    end
+  end
+
+  def star_or_not(rep_uri, pref_rep_uri)
+    if rep_uri == pref_rep_uri
+      "fa-star"
+    else
+      "fa-star-o"
     end
   end
 

--- a/app/presenters/concerns/citi_presenter_behaviors.rb
+++ b/app/presenters/concerns/citi_presenter_behaviors.rb
@@ -43,6 +43,7 @@ module CitiPresenterBehaviors
   end
 
   def representation_presenters
+    representation_ids.insert(0, preferred_representation_id).uniq! if preferred_representation_id
     CurationConcerns::PresenterFactory.build_presenters(representation_ids,
                                                         AssetPresenter,
                                                         *presenter_factory_arguments)

--- a/app/views/curation_concerns/base/_asset_relationship.html.erb
+++ b/app/views/curation_concerns/base/_asset_relationship.html.erb
@@ -3,6 +3,9 @@
 <table class="table table-striped relationships">
   <tbody>
     <tr>
+      <% if need_star %>
+        <th>Preferred</th>
+      <% end %>
       <th>Preview</th>
       <th>Document Type</th>
       <th>Link</th>
@@ -11,6 +14,9 @@
     </tr>
     <% presenters.each do |rel| %>
       <tr>
+        <% if need_star %>
+          <td><i class="fa <%= star_or_not(rel.id, pref_rep_id) %>"></i></td>
+        <% end %>
         <td><%= image_tag(rel.solr_document['thumbnail_path_ss']) %></td>
         <td><%= rel.document_types %></td>
         <td>

--- a/app/views/curation_concerns/base/_relationships_table.html.erb
+++ b/app/views/curation_concerns/base/_relationships_table.html.erb
@@ -1,7 +1,5 @@
 <% if presenter.citi_presenter? %>
-
-  <%= render_asset_relationship(presenter.preferred_representation_presenters, "Preferred Representation") %>
-  <%= render_asset_relationship(presenter.representation_presenters, "Representations") %>
+  <%= render_asset_relationship(presenter.representation_presenters, "Representations", true, presenter.preferred_representation_id) %>
   <%= render_asset_relationship(presenter.document_presenters, "Documentation") %>
 
 <% else %>

--- a/spec/features/show_citi_work_spec.rb
+++ b/spec/features/show_citi_work_spec.rb
@@ -32,7 +32,6 @@ describe "Displaying a CITI work" do
     expect(page).to have_selector("td", text: agent.pref_label)
     expect(page).to have_selector("th", text: "Current Location")
     expect(page).to have_selector("td", text: place.pref_label)
-    expect(page).to have_selector("h3", text: "Preferred Representation")
     expect(page).to have_selector("h3", text: "Representations")
     expect(page).to have_link(asset.pref_label)
     expect(page).to have_selector("th", text: "Non-Object Caption")


### PR DESCRIPTION
* https://cits.artic.edu/redmine/issues/2339

* remove preferred_reps table partial from nonasset show view
* tweak render_asset_relationship helper method to accept optional 3rd arg and pass it to asset_relationship partial as a local
* implement star_or_not method inside _asset_relationship partial & helper
* passing new 3rd arg of pref_rep_id to render partial method so that reps table can compare to each rep id to star it or not
* clicking on stars SHOULD NOT do anything on show action, increase specificity of element that jquery binds event to
* reorder citiwork presenter rep presenters that get passed to partial so starred is displayed as first <tr>
* work edit - document tr's should not have 'preferred' <th> and <td> when adding new ones