### PR TITLE
2034: add badges to relationships tables for visibility and publish channels

### DIFF
--- a/app/assets/stylesheets/aic_styles.scss
+++ b/app/assets/stylesheets/aic_styles.scss
@@ -166,3 +166,6 @@ p.unauthorized_asset_display.asset_title {
   font-size: 1.8em;
 }
 
+table.relationships .label {
+  display: inline-block;
+}

--- a/app/helpers/asset_relationship_helper.rb
+++ b/app/helpers/asset_relationship_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module AssetRelationshipHelper
+  # Requires an array of publish channels
+  def publish_channels_to_badges(publish_channels)
+    html = []
+
+    publish_channels.each do |publish_channel|
+      html << content_tag(:span, publish_channel, title: publish_channel, class: "label label-primary")
+    end
+    html.join.html_safe
+  end
+end

--- a/app/views/curation_concerns/base/_asset_relationship.html.erb
+++ b/app/views/curation_concerns/base/_asset_relationship.html.erb
@@ -9,6 +9,7 @@
       <th>Preview</th>
       <th>Document Type</th>
       <th>Link</th>
+      <th>Visibility & Publishing</th>
       <th>UID</th>
       <th>Non-Object Caption</th>
     </tr>
@@ -25,6 +26,9 @@
           <% else %>
             <%= rel.to_s %>
           <% end %>
+        </td>
+        <td>
+          <%= rel.permission_badge %><%= publish_channels_to_badges(rel.publish_channels) %>
         </td>
         <td><%= rel.uid %></td>
         <td><%= rel.caption %></td>


### PR DESCRIPTION
* https://cits.artic.edu/redmine/issues/2034

* added inline-block to .label so that multiple badges stack vertically and save width (per Becca)
* created publish_channels_to_badges helper method to produce span labels from array of channels
* inserted permission_badge and publish channels into asset_relationships partial