### PR TITLE
in LCL, decrease the amount of user_notification requests to every 5min

### DIFF
--- a/app/views/users/_notify_number.html.erb
+++ b/app/views/users/_notify_number.html.erb
@@ -1,0 +1,3 @@
+<span class="notify_number label label-default" data-update-poll-url="<%= sufia.user_notify_path %>" data-update-poll-interval="<% ENV["USER_NOTIFICATION_FREQ"] %>">
+  <span class="count">0</span> <span class="sr-only">unread notifications</span>
+</span>

--- a/app/views/users/_notify_number.html.erb
+++ b/app/views/users/_notify_number.html.erb
@@ -1,3 +1,3 @@
-<span class="notify_number label label-default" data-update-poll-url="<%= sufia.user_notify_path %>" data-update-poll-interval="<% ENV["USER_NOTIFICATION_FREQ"] %>">
+<span class="notify_number label label-default" data-update-poll-url="<%= sufia.user_notify_path %>" data-update-poll-interval="<%= ENV["USER_NOTIFICATION_FREQ"] %>">
   <span class="count">0</span> <span class="sr-only">unread notifications</span>
 </span>

--- a/config/application.yml
+++ b/config/application.yml
@@ -4,6 +4,7 @@ development:
   hydra_bin_path: "/usr/local/bin"
   LAKESHORE_ENV: "local"
   LAKESHORE_DOMAIN: "localhost:3000"
+  USER_NOTIFICATION_FREQ: "300"
 
 test:
   citi_api_uid: "citi_api_uid"
@@ -12,6 +13,7 @@ test:
   citi_api_ssl_verify: "false"
   hydra_bin_path: "/usr/local/bin"
   LAKESHORE_DOMAIN: "localhost:3000"
+  USER_NOTIFICATION_FREQ: "30"
 
 production:
 
@@ -33,3 +35,4 @@ production:
   # is self-signed or is some another signing authority that is not in the system's certificate chain.
   # Note: verification will only be skipped if the value is set to "false". All other values evaluate to "true".
   citi_api_ssl_verify: "false"
+  USER_NOTIFICATION_FREQ: "30"


### PR DESCRIPTION
logs are too full in LCL...

# NOTE: we will have to add these to the application.yml in each environment we deploy to otherwise the var will not be there in the html element's attribute and the javascript will assume an interval of 0sec and will let requests rip infinitely.