### PR TITLE
few small improvements for decreasing user notifications in LCL

### DIFF
--- a/app/views/users/_notify_number.html.erb
+++ b/app/views/users/_notify_number.html.erb
@@ -1,3 +1,3 @@
-<span class="notify_number label label-default" data-update-poll-url="<%= sufia.user_notify_path %>" data-update-poll-interval="<%= ENV["USER_NOTIFICATION_FREQ"] %>">
+<span class="notify_number label label-default" data-update-poll-url="<%= sufia.user_notify_path %>" data-update-poll-interval="<%= Figaro.env.user_notification_freq %>">
   <span class="count">0</span> <span class="sr-only">unread notifications</span>
 </span>

--- a/config/application.yml
+++ b/config/application.yml
@@ -4,7 +4,7 @@ development:
   hydra_bin_path: "/usr/local/bin"
   LAKESHORE_ENV: "local"
   LAKESHORE_DOMAIN: "localhost:3000"
-  USER_NOTIFICATION_FREQ: "300"
+  user_notification_freq: "300"
 
 test:
   citi_api_uid: "citi_api_uid"
@@ -13,7 +13,7 @@ test:
   citi_api_ssl_verify: "false"
   hydra_bin_path: "/usr/local/bin"
   LAKESHORE_DOMAIN: "localhost:3000"
-  USER_NOTIFICATION_FREQ: "30"
+  user_notification_freq: "30"
 
 production:
 
@@ -35,4 +35,4 @@ production:
   # is self-signed or is some another signing authority that is not in the system's certificate chain.
   # Note: verification will only be skipped if the value is set to "false". All other values evaluate to "true".
   citi_api_ssl_verify: "false"
-  USER_NOTIFICATION_FREQ: "30"
+  user_notification_freq: "30"

--- a/config/initializers/figaro.rb
+++ b/config/initializers/figaro.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+Figaro.require_keys("user_notification_freq")


### PR DESCRIPTION
Added a safety net in figaro.rb so if the rails app inits without the env var set, it raises an error. 