### PR TITLE
2647: API fileset file replacements should be in fileset activity in GUI

### DIFF
--- a/app/services/file_set_replacement_service.rb
+++ b/app/services/file_set_replacement_service.rb
@@ -31,6 +31,7 @@ class FileSetReplacementService
     file_set.title = [file.file.file.original_filename]
     file_set.save!
     file_actor.new(file_set, "original_file", user).ingest_file(file.file)
+    CurationConcerns.config.callback.run(:after_update_content, file_set, user)
     true
   end
 


### PR DESCRIPTION
extra spec verbally communicated from Stefano, that was not merged in b/c PR was never made, almost released without it :(