### PR TITLE
Orphaned ACLs from batch edit

### DIFF
--- a/app/controllers/batch_edits_controller.rb
+++ b/app/controllers/batch_edits_controller.rb
@@ -68,16 +68,14 @@ class BatchEditsController < ApplicationController
     end
 
     # Remove (and its commit) when https://github.com/projecthydra/sufia/issues/2450 is closed
-    # Updates terms, permissions, and visibility for a given object in a batch.
-    # Note: Permissions and visibility are *always* copied down to any contained FileSet objects.
-    #       There is no UI option presented to the user to prevent this, unlike the option that
-    #       is present when changing permissions on a single work.
+    # Updates terms and visibility for a given object in a batch.
+    # Note: Visibility is copied down to any contained FileSet objects, but
+    #       permissions are not because file sets use the same ACLs as its parent asset.
     def update_asset(obj)
       visibility_changed = visibility_status(obj)
       actor = CurationConcerns::Actors::ActorStack.new(obj, current_user, actor_stack)
       actor.update(work_params)
       VisibilityCopyJob.perform_later(obj) if visibility_changed
-      InheritPermissionsJob.perform_later(obj) if work_params.fetch(:permissions_attributes, nil)
     end
 
     def form_class

--- a/spec/controllers/batch_edits_controller_spec.rb
+++ b/spec/controllers/batch_edits_controller_spec.rb
@@ -115,7 +115,7 @@ describe BatchEditsController do
 
       it "updates the permissions on all the works" do
         expect(VisibilityCopyJob).not_to receive(:perform_later)
-        expect(InheritPermissionsJob).to receive(:perform_later).twice
+        expect(InheritPermissionsJob).not_to receive(:perform_later)
         put :update, parameters.as_json
         expect(work1.reload.edit_groups).to include("newgroop")
         expect(work2.reload.edit_groups).to include("newgroop")


### PR DESCRIPTION
InheritPermissionsJob was running when assets' permissions were changed
which was resulting in orphaned assets being created in Fedora outside
of the base path.

Because file sets use the same ACL resources as their parent assets,
there is no longer any need for file sets to inherit their
permissions--they already are by virtue of using the same ACLs.

Removing the call to InheritPermissionsJob fixes the orphaned ACL issue.

### QUESTIONS/TODO's
- [ ] verify this fixes the issue in staging
- [ ] delete the remaining orphaned ACLs in production once this is deployed 

