### PR TITLE
.travis.yml uses hard-coded ruby version, needs to rely on .ruby-version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 sudo: false
-rvm:
-  - 2.3.1
 cache:
   bundler: true
   directories:


### PR DESCRIPTION
resolves #468
https://cits.artic.edu/issues/2850

all environments need to use the same ruby version.

Travis currently uses "rvm": "2.3.1", from the yaml, but if you remove it will wonderfully fallback to the .ruby-version file.
https://docs.travis-ci.com/user/languages/ruby/#Using-.ruby-version