### PR TITLE
2913: TASK: update objects in CITI with recently updated preferred representation imaging_uid's

### DIFF
--- a/lib/tasks/citi_notifications.rake
+++ b/lib/tasks/citi_notifications.rake
@@ -1,5 +1,5 @@
 namespace :citi_notifications do
-  desc "TODO"
+  desc "Send image_uid notifications to CITI for assets that have been modified since a certain date 'YYYY-MM-DD'"
   task :update_imaging_uids, [:modified_after] => :environment do |t, args|
     date_passed_in = args[:modified_after]
     new_solr_date = date_passed_in + "T00:00:00Z"
@@ -33,6 +33,36 @@ namespace :citi_notifications do
       puts "Enqueueing CitiNotificationJob for #{gw.title}"
       CitiNotificationJob.perform_later(intermediate_file_set, nil, true)
     end
+  end
+
+  desc "Counts the number assets that have been modified after a certain date 'YYYY-MM-DD', are preferred reps, and have an imaging uid"
+  task :count_assets_to_update, [:modified_after] => :environment do |t, args|
+    date_passed_in = args[:modified_after]
+    new_solr_date = date_passed_in + "T00:00:00Z"
+
+    solr_docs = GenericWork.where("system_modified_dtsi:[#{new_solr_date} TO NOW]")
+    puts "Found #{solr_docs.count} GenericWork's in Solr, modified since #{date_passed_in}."
+
+    asset_ids = solr_docs.map(&:id)
+    asset_ids_that_are_preferred_reps = []
+
+    asset_ids.each do |asset_id|
+      inbound_relationship_object = InboundRelationships.new(asset_id)
+      asset_ids_that_are_preferred_reps << asset_id if inbound_relationship_object.preferred_representation.present?
+    end
+
+    puts "Found #{asset_ids_that_are_preferred_reps.count} assets that are also a preferred rep."
+
+    asset_objects_that_are_preferred_reps_and_have_an_imaging_uid = []
+
+    asset_ids_that_are_preferred_reps.each do |asset_id|
+      gw_object = GenericWork.find(asset_id)
+      if gw_object.imaging_uid.present?
+        asset_objects_that_are_preferred_reps_and_have_an_imaging_uid << gw_object
+      end
+    end
+
+    puts "Would send #{asset_objects_that_are_preferred_reps_and_have_an_imaging_uid.count} notifications to CITI, if ran."
   end
 end
 

--- a/lib/tasks/citi_notifications.rake
+++ b/lib/tasks/citi_notifications.rake
@@ -34,7 +34,9 @@ namespace :citi_notifications do
     # go through all assets in subset 1 and reduce to those that are a preferred
     asset_ids.each do |asset_id|
       inbound_relationship_object = InboundRelationships.new(asset_id)
-      asset_objects_that_are_preferred_reps << GenericWork.find(asset_id) if inbound_relationship_object.preferred_representation.present?
+      if inbound_relationship_object.preferred_representation.present?
+        asset_objects_that_are_preferred_reps << GenericWork.find(asset_id)
+      end
     end
 
     # tell the user how many assets are also a preferred rep
@@ -60,7 +62,9 @@ namespace :citi_notifications do
 
     asset_ids.each do |asset_id|
       inbound_relationship_object = InboundRelationships.new(asset_id)
-      asset_objects_that_are_preferred_reps << GenericWork.find(asset_id) if inbound_relationship_object.preferred_representation.present?
+      if inbound_relationship_object.preferred_representation.present?
+        asset_objects_that_are_preferred_reps << GenericWork.find(asset_id)
+      end
     end
 
     puts "Would send #{asset_objects_that_are_preferred_reps.count} notifications to CITI, if ran."

--- a/lib/tasks/citi_notifications.rake
+++ b/lib/tasks/citi_notifications.rake
@@ -14,36 +14,35 @@ end
 namespace :citi_notifications do
   desc "Send image_uid notifications to CITI for assets that have been modified since a certain date 'YYYY-MM-DD'"
   task :update_imaging_uids, [:modified_after] => :environment do |_t, args|
+    # pull out date passed in
     date_passed_in = args[:modified_after]
+
+    # add date to time to create timestamp for solr query
     new_solr_date = date_passed_in + "T00:00:00Z"
 
+    # find the assets edited since a specific date
     solr_docs = GenericWork.where("system_modified_dtsi:[#{new_solr_date} TO NOW]")
+
+    # tell the user how many found
     puts "Found #{solr_docs.count} GenericWork's in Solr, modified since #{date_passed_in}."
 
+    # convert array of solr docs to array of id's
     asset_ids = solr_docs.map(&:id)
-    asset_ids_that_are_preferred_reps = []
 
+    asset_objects_that_are_preferred_reps = []
+
+    # go through all assets in subset 1 and reduce to those that are a preferred
     asset_ids.each do |asset_id|
       inbound_relationship_object = InboundRelationships.new(asset_id)
-      asset_ids_that_are_preferred_reps << asset_id if inbound_relationship_object.preferred_representation.present?
+      asset_objects_that_are_preferred_reps << GenericWork.find(asset_id) if inbound_relationship_object.preferred_representation.present?
     end
 
-    puts "Found #{asset_ids_that_are_preferred_reps.count} assets that are also a preferred rep."
+    # tell the user how many assets are also a preferred rep
+    puts "Found #{asset_objects_that_are_preferred_reps.count} assets that are also a preferred rep."
 
-    asset_objects_that_are_preferred_reps_and_have_an_imaging_uid = []
-
-    asset_ids_that_are_preferred_reps.each do |asset_id|
-      gw_object = GenericWork.find(asset_id)
-      if gw_object.imaging_uid.present?
-        asset_objects_that_are_preferred_reps_and_have_an_imaging_uid << gw_object
-      end
-    end
-
-    puts "Found #{asset_objects_that_are_preferred_reps_and_have_an_imaging_uid.count} assets that have a non-empty imaging_uid."
-
-    asset_objects_that_are_preferred_reps_and_have_an_imaging_uid.each do |gw|
-      intermediate_file_set = gw.intermediate_file_set.first
-      puts "Enqueueing CitiNotificationJob for #{gw.title}"
+    asset_objects_that_are_preferred_reps.each do |generic_work_object|
+      intermediate_file_set = generic_work_object.intermediate_file_set.first
+      puts "Enqueueing CitiNotificationJob for #{generic_work_object.title}"
       CitiNotificationJob.perform_later(intermediate_file_set, nil, true)
     end
   end
@@ -57,25 +56,14 @@ namespace :citi_notifications do
     puts "Found #{solr_docs.count} GenericWork's in Solr, modified since #{date_passed_in}."
 
     asset_ids = solr_docs.map(&:id)
-    asset_ids_that_are_preferred_reps = []
+    asset_objects_that_are_preferred_reps = []
 
     asset_ids.each do |asset_id|
       inbound_relationship_object = InboundRelationships.new(asset_id)
-      asset_ids_that_are_preferred_reps << asset_id if inbound_relationship_object.preferred_representation.present?
+      asset_objects_that_are_preferred_reps << GenericWork.find(asset_id) if inbound_relationship_object.preferred_representation.present?
     end
 
-    puts "Found #{asset_ids_that_are_preferred_reps.count} assets that are also a preferred rep."
-
-    asset_objects_that_are_preferred_reps_and_have_an_imaging_uid = []
-
-    asset_ids_that_are_preferred_reps.each do |asset_id|
-      gw_object = GenericWork.find(asset_id)
-      if gw_object.imaging_uid.present?
-        asset_objects_that_are_preferred_reps_and_have_an_imaging_uid << gw_object
-      end
-    end
-
-    puts "Would send #{asset_objects_that_are_preferred_reps_and_have_an_imaging_uid.count} notifications to CITI, if ran."
+    puts "Would send #{asset_objects_that_are_preferred_reps.count} notifications to CITI, if ran."
   end
 end
 

--- a/lib/tasks/citi_notifications.rake
+++ b/lib/tasks/citi_notifications.rake
@@ -12,62 +12,41 @@ class Rake::Task
 end
 
 namespace :citi_notifications do
-  desc "Send image_uid notifications to CITI for assets that have been modified since a certain date 'YYYY-MM-DD'"
-  task :update_imaging_uids, [:modified_after] => :environment do |_t, args|
-    # pull out date passed in
-    date_passed_in = args[:modified_after]
-
-    # add date to time to create timestamp for solr query
-    new_solr_date = date_passed_in + "T00:00:00Z"
-
-    # find the assets edited since a specific date
-    solr_docs = GenericWork.where("system_modified_dtsi:[#{new_solr_date} TO NOW]")
-
-    # tell the user how many found
-    puts "Found #{solr_docs.count} GenericWork's in Solr, modified since #{date_passed_in}."
-
-    # convert array of solr docs to array of id's
-    asset_ids = solr_docs.map(&:id)
-
-    asset_objects_that_are_preferred_reps = []
-
-    # go through all assets in subset 1 and reduce to those that are a preferred
-    asset_ids.each do |asset_id|
-      inbound_relationship_object = InboundRelationships.new(asset_id)
-      if inbound_relationship_object.preferred_representation.present?
-        asset_objects_that_are_preferred_reps << GenericWork.find(asset_id)
-      end
-    end
-
-    # tell the user how many assets are also a preferred rep
-    puts "Found #{asset_objects_that_are_preferred_reps.count} assets that are also a preferred rep."
-
-    asset_objects_that_are_preferred_reps.each do |generic_work_object|
-      intermediate_file_set = generic_work_object.intermediate_file_set.first
-      puts "Enqueueing CitiNotificationJob for #{generic_work_object.title}"
-      CitiNotificationJob.perform_later(intermediate_file_set, nil, true)
-    end
-  end
-
   desc "Counts the number assets that have been modified after a certain date 'YYYY-MM-DD', are preferred reps, and have an imaging uid"
   task :count_assets_to_update, [:modified_after] => :environment do |_t, args|
     date_passed_in = args[:modified_after]
     new_solr_date = date_passed_in + "T00:00:00Z"
 
-    solr_docs = GenericWork.where("system_modified_dtsi:[#{new_solr_date} TO NOW]")
-    puts "Found #{solr_docs.count} GenericWork's in Solr, modified since #{date_passed_in}."
+    query = "{!join from=preferred_representation_ssim to=id}preferred_representation_ssim:*"
+    fq = []
+    fq << "has_model_ssim:GenericWork"
+    fq << "system_modified_dtsi:[#{new_solr_date} TO NOW]"
 
-    asset_ids = solr_docs.map(&:id)
-    asset_objects_that_are_preferred_reps = []
+    asset_ids = ActiveFedora::SolrService.query( query, { fq: fq, rows: 100_000 } ).map(&:id)
+
+    puts "Found #{asset_ids.count} preferred rep assets in Solr, edited after #{args[:modified_after]}."
+  end
+
+  desc "Send image_uid notifications to CITI for assets that have been modified since a certain date 'YYYY-MM-DD'"
+  task :update_imaging_uids, [:modified_after] => :environment do |_t, args|
+    date_passed_in = args[:modified_after]
+    new_solr_date = date_passed_in + "T00:00:00Z"
+
+    query = "{!join from=preferred_representation_ssim to=id}preferred_representation_ssim:*"
+    fq = []
+    fq << "has_model_ssim:GenericWork"
+    fq << "system_modified_dtsi:[#{new_solr_date} TO NOW]"
+
+    asset_ids = ActiveFedora::SolrService.query( query, { fq: fq, rows: 100_000 } ).map(&:id)
 
     asset_ids.each do |asset_id|
-      inbound_relationship_object = InboundRelationships.new(asset_id)
-      if inbound_relationship_object.preferred_representation.present?
-        asset_objects_that_are_preferred_reps << GenericWork.find(asset_id)
-      end
+      generic_work_object = GenericWork.find(asset_id)
+      intermediate_file_set = generic_work_object.intermediate_file_set.first
+      puts "Enqueueing CitiNotificationJob for #{generic_work_object.try(:title)} last modified #{generic_work_object.date_modified}"
+      CitiNotificationJob.perform_later(intermediate_file_set, nil, true)
     end
 
-    puts "Would send #{asset_objects_that_are_preferred_reps.count} notifications to CITI, if ran."
+    puts "Task completed with a total of #{asset_ids.count} preferred rep assets, edited after #{args[:modified_after]}."
   end
 end
 

--- a/lib/tasks/citi_notifications.rake
+++ b/lib/tasks/citi_notifications.rake
@@ -1,6 +1,19 @@
+# frozen_string_literal: true
+require 'benchmark'
+
+class Rake::Task
+  def execute_with_benchmark(*args)
+    bm = Benchmark.measure { execute_without_benchmark(*args) }
+    puts "   #{name} --> #{bm}"
+  end
+
+  alias execute_without_benchmark execute
+  alias execute execute_with_benchmark
+end
+
 namespace :citi_notifications do
   desc "Send image_uid notifications to CITI for assets that have been modified since a certain date 'YYYY-MM-DD'"
-  task :update_imaging_uids, [:modified_after] => :environment do |t, args|
+  task :update_imaging_uids, [:modified_after] => :environment do |_t, args|
     date_passed_in = args[:modified_after]
     new_solr_date = date_passed_in + "T00:00:00Z"
 
@@ -36,7 +49,7 @@ namespace :citi_notifications do
   end
 
   desc "Counts the number assets that have been modified after a certain date 'YYYY-MM-DD', are preferred reps, and have an imaging uid"
-  task :count_assets_to_update, [:modified_after] => :environment do |t, args|
+  task :count_assets_to_update, [:modified_after] => :environment do |_t, args|
     date_passed_in = args[:modified_after]
     new_solr_date = date_passed_in + "T00:00:00Z"
 
@@ -66,9 +79,7 @@ namespace :citi_notifications do
   end
 end
 
-
 # GenericWork.where("system_modified_dtsi:[NOW/DAY TO NOW]")
 # https://lucene.apache.org/solr/guide/7_3/working-with-dates.html
 # GenericWork.where("system_modified_dtsi:[2018-02-28 TO NOW]")
-
 # 2018-02-28T00:00:00Z

--- a/lib/tasks/citi_notifications.rake
+++ b/lib/tasks/citi_notifications.rake
@@ -1,0 +1,44 @@
+namespace :citi_notifications do
+  desc "TODO"
+  task :update_imaging_uids, [:modified_after] => :environment do |t, args|
+    date_passed_in = args[:modified_after]
+    new_solr_date = date_passed_in + "T00:00:00Z"
+
+    solr_docs = GenericWork.where("system_modified_dtsi:[#{new_solr_date} TO NOW]")
+    puts "Found #{solr_docs.count} GenericWork's in Solr, modified since #{date_passed_in}."
+
+    asset_ids = solr_docs.map(&:id)
+    asset_ids_that_are_preferred_reps = []
+
+    asset_ids.each do |asset_id|
+      inbound_relationship_object = InboundRelationships.new(asset_id)
+      asset_ids_that_are_preferred_reps << asset_id if inbound_relationship_object.preferred_representation.present?
+    end
+
+    puts "Found #{asset_ids_that_are_preferred_reps.count} assets that are also a preferred rep."
+
+    asset_objects_that_are_preferred_reps_and_have_an_imaging_uid = []
+
+    asset_ids_that_are_preferred_reps.each do |asset_id|
+      gw_object = GenericWork.find(asset_id)
+      if gw_object.imaging_uid.present?
+        asset_objects_that_are_preferred_reps_and_have_an_imaging_uid << gw_object
+      end
+    end
+
+    puts "Found #{asset_objects_that_are_preferred_reps_and_have_an_imaging_uid.count} assets that have a non-empty imaging_uid."
+
+    asset_objects_that_are_preferred_reps_and_have_an_imaging_uid.each do |gw|
+      intermediate_file_set = gw.intermediate_file_set.first
+      puts "Enqueueing CitiNotificationJob for #{gw.title}"
+      CitiNotificationJob.perform_later(intermediate_file_set, nil, true)
+    end
+  end
+end
+
+
+# GenericWork.where("system_modified_dtsi:[NOW/DAY TO NOW]")
+# https://lucene.apache.org/solr/guide/7_3/working-with-dates.html
+# GenericWork.where("system_modified_dtsi:[2018-02-28 TO NOW]")
+
+# 2018-02-28T00:00:00Z


### PR DESCRIPTION
https://cits.artic.edu/issues/2913

When this is deployed to an environment, invoke from lakeshore's `current` directory.

To count the number of assets/jobs that would need to be sent:
```
bundle exec rake citi_notifications:count_assets_to_update["2018-02-28"] RAILS_ENV=production
```

OR, to run the actual CitiNotificationJobs, use:
```
bundle exec rake citi_notifications:update_imaging_uids["2018-02-28"] RAILS_ENV=production
```