### PR TITLE
2773: Check every file for duplicates in the ingest API

### DIFF
--- a/app/controllers/lakeshore/ingest_controller.rb
+++ b/app/controllers/lakeshore/ingest_controller.rb
@@ -6,7 +6,7 @@ module Lakeshore
     # load_and_authorize_resource :curation_concern, class: 'GenericWork'
 
     delegate :intermediate_file, :asset_type, :ingestor, :attributes_for_actor,
-             :check_duplicates_turned_off?, :represented_resources, :force_preferred_representation?, to: :ingest
+             :represented_resources, :force_preferred_representation?, to: :ingest
 
     before_action :validate_ingest, :validate_asset_type, only: [:create]
     before_action :validate_duplicate_upload, :validate_preferred_representations, only: [:create, :update]
@@ -41,10 +41,8 @@ module Lakeshore
       end
 
       def validate_duplicate_upload
-        return if check_duplicates_turned_off?
-        return if duplicate_upload.empty?
-        ingest.errors.add(:intermediate_file, "is a duplicate of #{duplicate_upload.first}")
-        render json: duplicate_error, status: :conflict
+        return if ingest.unique?
+        render json: ingest.duplicate_error, status: :conflict
       end
 
       def validate_preferred_representations
@@ -69,24 +67,6 @@ module Lakeshore
                               else
                                 GenericWork.new
                               end
-      end
-
-      def duplicate_upload
-        @duplicate_upload ||= DuplicateUploadVerificationService.new(intermediate_file).duplicate_file_sets
-      end
-
-      def duplicate_error
-        {
-          message: "Duplicate detected.",
-          uploaded_resource: {
-            id: ingest.params["metadata"].fetch("uid", nil),
-            file_name: intermediate_file.original_filename
-          },
-          stored_resource: {
-            fileset_id: duplicate_upload.first.id,
-            pref_label: duplicate_upload.first.parent.pref_label
-          }
-        }
       end
   end
 end

--- a/app/models/lakeshore/ingest_file.rb
+++ b/app/models/lakeshore/ingest_file.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+module Lakeshore
+  class IngestFile
+    attr_reader :file, :type, :user
+
+    delegate :original_filename, to: :file
+    delegate :errors, to: :uploaded_file
+
+    def self.uri_map
+      {
+        original: AICType.OriginalFileSet,
+        intermediate: AICType.IntermediateFileSet,
+        pres_master: AICType.PreservationMasterFileSet,
+        legacy: AICType.LegacyFileSet
+      }
+    end
+
+    def self.types
+      uri_map.keys
+    end
+
+    # @param [User] user depositor performing the ingest from the API
+    # @param [ActionDispatch::Http::UploadedFile] file uploaded from the API
+    # @param [Symbol] type for the FileSet that has a registered URI
+    def initialize(user:, file:, type:)
+      @type = type
+      @file = file
+      @user = user
+    end
+
+    def uri
+      @uri ||= register_uri
+    end
+
+    def duplicate?
+      errors.key?(:checksum)
+    end
+
+    def unique?
+      !duplicate?
+    end
+
+    def uploaded_file
+      @uploaded_file ||= create_file(file, user)
+    end
+
+    # @return [String] id of uploaded file for API
+    def uploaded_file_id
+      return if uploaded_file.nil?
+      uploaded_file.id.to_s
+    end
+
+    private
+
+      def register_uri
+        return if type.nil?
+        self.class.uri_map[type] || raise(UnsupportedFileSetTypeError, "'#{type}' is not a supported file set type")
+      end
+
+      def create_file(file, user)
+        return if file.nil?
+        Sufia::UploadedFile.create(file: file, user: user, use_uri: uri)
+      end
+
+      class UnsupportedFileSetTypeError < StandardError; end
+  end
+end

--- a/app/models/lakeshore/ingest_registry.rb
+++ b/app/models/lakeshore/ingest_registry.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+module Lakeshore
+  class IngestRegistry
+    attr_reader :intermediate_file, :user, :files
+
+    # @param [Hash] content from api request
+    # @param [User] user
+    def initialize(content, user)
+      @intermediate_file = register_intermediate_file(content.delete(:intermediate), user)
+      @user = user
+      @files = [@intermediate_file].compact
+      register_files(content)
+    end
+
+    # @param [true, false] if there are no duplicates in the set of files
+    def unique?
+      duplicates.empty?
+    end
+
+    # @return [Array<String>]
+    # Array of numeric ids for each Sufia::UploadedFile in the array of {files}
+    def upload_ids
+      return [] if duplicates.present?
+      files.map(&:uploaded_file_id).compact
+    end
+
+    # @return [Hash]
+    # @note creates a JSON report for duplicate typed and non-typed files
+    def duplicate_error
+      error = { message: "Duplicate files detected." }
+      IngestFile.types.each do |type|
+        error_files = duplicates.select { |file| (file.type == type) }
+        next if error_files.empty?
+        error[type] = error_files.map { |file| error_details(file) }
+      end
+
+      untyped_duplicates = duplicates.select { |file| file.type.nil? }
+      if untyped_duplicates.present?
+        error[:other] = untyped_duplicates.map { |file| error_details(file) }
+      end
+
+      error
+    end
+
+    private
+
+      def register_intermediate_file(file, user)
+        file = IngestFile.new(user: user, file: file, type: :intermediate)
+        return if file.file.nil?
+        file
+      end
+
+      # @note creates ingest files for both typed and non-typed files
+      def register_files(content)
+        (content.keys.map(&:to_sym) & IngestFile.types).each do |type|
+          files << IngestFile.new(user: user, file: content.delete(type), type: type)
+        end
+
+        content.values.map do |file|
+          files << IngestFile.new(user: user, file: file, type: nil)
+        end
+      end
+
+      def duplicates
+        @duplicates ||= files.select(&:duplicate?)
+      end
+
+      def error_details(file)
+        {
+          error: "#{file.errors.messages[:checksum].first[:error]} "\
+                 "#{file.errors.messages[:checksum].first[:duplicate_name]}",
+          path: file.errors.messages[:checksum].first[:duplicate_path]
+        }
+      end
+  end
+end

--- a/app/services/asset_type_verification_service.rb
+++ b/app/services/asset_type_verification_service.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class AssetTypeVerificationService
   class << self
-    # @param [Rack::Test::UploadedFile] file uploaded via Rack
+    # @param [ActionDispatch::Http::UploadedFile, Lakeshore::IngestFile] file uploaded via Rack
     # @param [AICType, String] asset_type
     # @return [Boolean]
     def call(file, asset_type)

--- a/app/services/duplicate_upload_verification_service.rb
+++ b/app/services/duplicate_upload_verification_service.rb
@@ -6,7 +6,7 @@ class DuplicateUploadVerificationService
     new(file).duplicate_file_sets.empty?
   end
 
-  # @param [Sufia::UploadedFile] file uploaded via Rack
+  # @param [ActionDispatch::Http::UploadedFile, Sufia::UploadedFile] file uploaded via Rack
   def initialize(file)
     @file = file
   end

--- a/spec/controllers/lakeshore/ingest_controller/create_duplicates_spec.rb
+++ b/spec/controllers/lakeshore/ingest_controller/create_duplicates_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: false
+require 'rails_helper'
+
+describe Lakeshore::IngestController, custom_description: "Lakeshore::IngestController#create" do
+  let(:apiuser)  { create(:apiuser) }
+  let(:user)     { create(:user1) }
+  let(:file_set) { build(:file_set, id: "existing-file-set-id") }
+  let(:parent)   { build(:work, pref_label: "work pref_label") }
+
+  let(:image_asset) do
+    ActionDispatch::Http::UploadedFile.new(filename:     "sun.png",
+                                           content_type: "image/png",
+                                           tempfile:     File.new(File.join(fixture_path, "sun.png")))
+  end
+
+  context "when uploading a duplicate file" do
+    let(:json_response) { JSON.parse(File.open(File.join(fixture_path, "api_409.json")).read).to_json }
+
+    let(:metadata) do
+      {
+        "visibility" => "department",
+        "depositor" => user.email,
+        "document_type_uri" => AICDocType.ConservationStillImage,
+        "uid" => "upload-id"
+      }
+    end
+
+    before do
+      sign_in_basic(apiuser)
+      allow(AssetTypeVerificationService).to receive(:call).and_return(true)
+      allow(file_set).to receive(:parent).and_return(parent)
+      allow_any_instance_of(ChecksumValidator).to receive(:duplicate_file_sets).and_return([file_set])
+      post :create, asset_type: "StillImage", content: { intermediate: image_asset }, metadata: metadata
+    end
+
+    it "returns an error with the correct status" do
+      expect(response.status).to eq(409)
+      expect(response.body).to eq(json_response)
+    end
+  end
+end

--- a/spec/controllers/lakeshore/ingest_controller/update_spec.rb
+++ b/spec/controllers/lakeshore/ingest_controller/update_spec.rb
@@ -32,7 +32,6 @@ describe Lakeshore::IngestController, custom_description: "Lakeshore::IngestCont
     before do
       LakeshoreTesting.restore
       allow(Lakeshore::CreateAllDerivatives).to receive(:perform_later)
-      allow(controller).to receive(:duplicate_upload).and_return([])
     end
 
     context "with an intermediate file" do
@@ -153,10 +152,11 @@ describe Lakeshore::IngestController, custom_description: "Lakeshore::IngestCont
     let(:parent)   { build(:work, pref_label: "work pref_label") }
 
     before do
+      allow_any_instance_of(ChecksumValidator).to receive(:duplicate_file_sets).and_return([file_set])
       allow(Lakeshore::CreateAllDerivatives).to receive(:perform_later)
-      allow(controller).to receive(:duplicate_upload).and_return([file_set])
       allow(file_set).to receive(:parent).and_return(parent)
-      post :update, id: asset.id, content: { intermediate: replacement_asset }, metadata: metadata, duplicate_check: duplicate_check_param
+      post :update, id: asset.id, content: { intermediate: replacement_asset },
+                    metadata: metadata, duplicate_check: duplicate_check_param
       asset.reload
     end
 

--- a/spec/fixtures/api_409.json
+++ b/spec/fixtures/api_409.json
@@ -1,11 +1,9 @@
 {
-  "message" : "Duplicate detected.",
-  "uploaded_resource" : {
-    "id": "upload-id",
-    "file_name" : "sun.png"
-  },
-  "stored_resource" : {
-    "fileset_id" : "existing-file-set-id",
-    "pref_label" : "work pref_label"
-  }
+  "message" : "Duplicate files detected.",
+  "intermediate" : [
+    {
+      "error" : "sun.png is a duplicate of: work pref_label",
+      "path" : "/concern/works"
+    }
+  ]
 }

--- a/spec/models/lakeshore/ingest_file_spec.rb
+++ b/spec/models/lakeshore/ingest_file_spec.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+RSpec.describe Lakeshore::IngestFile do
+  let(:user) { create(:user) }
+  let(:type) { :original }
+
+  let(:file) do
+    ActionDispatch::Http::UploadedFile.new(filename:     "sun.png",
+                                           content_type: "image/png",
+                                           tempfile:     File.new(File.join(fixture_path, "sun.png")))
+  end
+
+  subject { described_class.new(file: file, user: user, type: type) }
+
+  it { is_expected.to delegate_method(:original_filename).to(:file) }
+  it { is_expected.to delegate_method(:errors).to(:uploaded_file) }
+
+  describe "::types" do
+    subject { described_class }
+    its(:types) { is_expected.to contain_exactly(:original, :intermediate, :pres_master, :legacy) }
+  end
+
+  describe "#uploaded_file" do
+    its(:uploaded_file) { is_expected.to be_a(Sufia::UploadedFile) }
+  end
+
+  describe "#uri" do
+    context "with an original file" do
+      its(:uri) { is_expected.to eq(AICType.OriginalFileSet) }
+    end
+
+    context "with an intermediate file" do
+      let(:type) { :intermediate }
+      its(:uri) { is_expected.to eq(AICType.IntermediateFileSet) }
+    end
+
+    context "with an original file" do
+      let(:type) { :pres_master }
+      its(:uri) { is_expected.to eq(AICType.PreservationMasterFileSet) }
+    end
+
+    context "with an original file" do
+      let(:type) { :legacy }
+      its(:uri) { is_expected.to eq(AICType.LegacyFileSet) }
+    end
+
+    context "without a file type" do
+      let(:type) { nil }
+      its(:uri) { is_expected.to be_nil }
+    end
+
+    context "with an unregistered file" do
+      let(:type) { :unregistered }
+      it "raises an error" do
+        expect {
+          described_class.new(file: file, user: user, type: :unregistered).uri
+        }.to raise_error(Lakeshore::IngestFile::UnsupportedFileSetTypeError,
+                         "'unregistered' is not a supported file set type")
+      end
+    end
+  end
+
+  describe "#duplicate? and #unique?" do
+    context "with a unique file" do
+      it { is_expected.not_to be_duplicate }
+      it { is_expected.to be_unique }
+    end
+
+    context "with a duplicate file" do
+      before { allow(subject).to receive(:errors).and_return(checksum: "error") }
+
+      it { is_expected.to be_duplicate }
+      it { is_expected.not_to be_unique }
+    end
+  end
+end

--- a/spec/models/lakeshore/ingest_registry_spec.rb
+++ b/spec/models/lakeshore/ingest_registry_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Lakeshore::IngestRegistry do
+  let(:user) { create(:user) }
+
+  subject(:registry) { described_class.new(content, user) }
+
+  describe "unique?" do
+    context "without any content in the api request" do
+      let(:content) { {} }
+      it { is_expected.to be_unique }
+    end
+
+    context "with non-duplicate files" do
+      let(:content) { { intermediate: "intermediate file", pres_master: "pres master file" } }
+      before { allow(registry).to receive(:duplicates).and_return([]) }
+      it { is_expected.to be_unique }
+    end
+
+    context "with one or more duplicate files in the registry" do
+      let(:content) { { intermediate: "intermediate file", pres_master: "duplicate" } }
+      before { allow(registry).to receive(:duplicates).and_return(["duplicate"]) }
+      it { is_expected.not_to be_unique }
+    end
+  end
+
+  describe "#intermediate_file" do
+    context "without any content from the api request" do
+      let(:content) { {} }
+      its(:intermediate_file) { is_expected.to be_nil }
+    end
+  end
+
+  describe "#files" do
+    context "without any content in the api request" do
+      let(:content) { {} }
+      subject { registry }
+
+      its(:files) { is_expected.to be_empty }
+    end
+
+    context "with both named and non-named file types in the api request" do
+      let(:content) { { intermediate: "intermediate file", pres_master: "pres master file", other: "other file" } }
+
+      it "is an array of ingest files" do
+        expect(registry.files.count).to eq(3)
+      end
+    end
+
+    context "with only named file types in the api request" do
+      let(:content) { { intermediate: "intermediate file", pres_master: "pres master file" } }
+
+      it "is an array of ingest files" do
+        expect(registry.files.count).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# REDMINE URL: https://cits.artic.edu/issues/2773

Adds support for duplicate checking of all files submitted to the ingest API, not just intermediate files.

### SUPPORTING INFO

Refactors Lakshore::Ingest and Lakeshore::IngestController to remove unnecessary code, and creates two new classes: Lakeshore::IngestFile and Lakeshore::IngestRegistry.

The Lakeshore::IngestFile class controls a file's duplicate status, its file set type uri, and its upload to Lakeshore as a Sufia::UploadedFile. IngestFile will check for a duplicate even before an UploadedFile is created, thus removing a hidden bug whereby the uploaded file was created even if the file did in fact exist already. This brings the ingest API more inline with the GUI implementation that rejects duplicate files prior to uploading them as Sufia::UploadedFile objects.

Because files are submitted to the ingest API all at once, the IngestRegistry class distinguishes between the intermediate file, which takes precedence, and any other file type in the request. The registry's main responsibilities are to identify the intermediate file, flag any request as "not unique" if it contains any duplicate files, and to create the set of uploaded ids that are passed the actor stack in the controller. These ids are the Sufia::UploadedFile ids that are only created if all the files in the registry are unique. Note, this now means that no files are permitted through unless _all_ the files in the API request are unique.

Lakeshore::Ingest delegates all file questions and concerns to the IngestRegsitry, which unburdens it from a lot of code. The ingest class now only has to assemble metadata, files via the registry, and perform some validations.

Lastly, Lakeshore::IngestController only has the responsibility of checking the validity of the request by asking the Lakeshore::Ingest class, and either reporting the errors or passing the request on to the actor stack. 
