### PR TITLE
2943: non-memoize file creation processes so they get invoked even when LakeshoreTesting.restor'ing

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,4 +1,3 @@
 --color
 --profile
 --format documentation
---format progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,6 @@ matrix:
 script:
   - "bundle exec rake ci:$TEST_SUITE"
 
-after_script:
-  - "echo $LAKESHORE_ENV"
-
 notifications:
   email:
     recipients:

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ matrix:
 script:
   - "bundle exec rake ci:$TEST_SUITE"
 
+after_script:
+  - "echo $LAKESHORE_ENV"
+
 notifications:
   email:
     recipients:

--- a/spec/controllers/lakeshore/ingest_controller/create_spec.rb
+++ b/spec/controllers/lakeshore/ingest_controller/create_spec.rb
@@ -12,6 +12,7 @@ describe Lakeshore::IngestController, custom_description: "Lakeshore::IngestCont
   end
 
   before do
+    LakeshoreTesting.reset_uploads
     sign_in_basic(apiuser)
   end
 
@@ -20,6 +21,7 @@ describe Lakeshore::IngestController, custom_description: "Lakeshore::IngestCont
   end
 
   context "when uploading a file" do
+    before { LakeshoreTesting.restore }
     it "successfully adds the fileset to the work" do
       expect(Lakeshore::AttachFilesToWorkJob).to receive(:perform_later)
       post :create, asset_type: "StillImage", content: { intermediate: image_asset }, metadata: metadata
@@ -40,6 +42,8 @@ describe Lakeshore::IngestController, custom_description: "Lakeshore::IngestCont
       }
     end
     let(:asset) { GenericWork.where(uid: "SI-99").first }
+
+    before { LakeshoreTesting.restore }
 
     it "successfully creates the the work" do
       expect(Lakeshore::AttachFilesToWorkJob).to receive(:perform_later)
@@ -152,8 +156,9 @@ describe Lakeshore::IngestController, custom_description: "Lakeshore::IngestCont
       }
     end
 
+    before { LakeshoreTesting.restore }
+
     it "updates the non_asset with the preferred representation" do
-      LakeshoreTesting.restore(reset_tmp_files: false)
       expect(Lakeshore::AttachFilesToWorkJob).to receive(:perform_later)
       expect(non_asset.preferred_representation_uri).to be_nil
       post :create, asset_type: "StillImage", content: { intermediate: image_asset }, metadata: metadata
@@ -197,6 +202,8 @@ describe Lakeshore::IngestController, custom_description: "Lakeshore::IngestCont
         "preferred_representation_for" => [non_asset.id]
       }
     end
+
+    before { LakeshoreTesting.restore }
 
     it "updates the non_asset with the new preferred representation" do
       expect(Lakeshore::AttachFilesToWorkJob).to receive(:perform_later)

--- a/spec/controllers/lakeshore/ingest_controller/create_spec.rb
+++ b/spec/controllers/lakeshore/ingest_controller/create_spec.rb
@@ -5,7 +5,7 @@ describe Lakeshore::IngestController, custom_description: "Lakeshore::IngestCont
   let(:apiuser) { create(:apiuser) }
   let(:user)    { create(:user1) }
 
-  let(:image_asset) do
+  let!(:image_asset) do
     ActionDispatch::Http::UploadedFile.new(filename:     "sun.png",
                                            content_type: "image/png",
                                            tempfile:     File.new(File.join(fixture_path, "sun.png")))

--- a/spec/controllers/lakeshore/ingest_controller/create_spec.rb
+++ b/spec/controllers/lakeshore/ingest_controller/create_spec.rb
@@ -5,6 +5,8 @@ describe Lakeshore::IngestController, custom_description: "Lakeshore::IngestCont
   let(:apiuser) { create(:apiuser) }
   let(:user)    { create(:user1) }
 
+  # bang this so it is not memoized and gets invoked even after tmp dir is wiped via LakeshoreTesting
+  # https://cits.artic.edu/issues/2943
   let!(:image_asset) do
     ActionDispatch::Http::UploadedFile.new(filename:     "sun.png",
                                            content_type: "image/png",

--- a/spec/controllers/lakeshore/ingest_controller/update_spec.rb
+++ b/spec/controllers/lakeshore/ingest_controller/update_spec.rb
@@ -5,13 +5,17 @@ describe Lakeshore::IngestController, custom_description: "Lakeshore::IngestCont
   let(:apiuser) { create(:apiuser) }
   let(:user)    { create(:user1) }
 
-  let(:image_asset) do
+  # bang this so it is not memoized and gets invoked even after tmp dir is wiped via LakeshoreTesting
+  # https://cits.artic.edu/issues/2943
+  let!(:image_asset) do
     ActionDispatch::Http::UploadedFile.new(filename:     "sun.png",
                                            content_type: "image/png",
                                            tempfile:     File.new(File.join(fixture_path, "sun.png")))
   end
 
-  let(:replacement_asset) do
+  # bang this so it is not memoized and gets invoked even after tmp dir is wiped via LakeshoreTesting
+  # https://cits.artic.edu/issues/2943
+  let!(:replacement_asset) do
     ActionDispatch::Http::UploadedFile.new(filename:     "tardis.png",
                                            content_type: "image/png",
                                            tempfile:     File.new(File.join(fixture_path, "tardis.png")))

--- a/spec/models/sufia/uploaded_file_spec.rb
+++ b/spec/models/sufia/uploaded_file_spec.rb
@@ -2,7 +2,9 @@
 require 'rails_helper'
 
 describe Sufia::UploadedFile do
-  let(:file) do
+  # bang this so it is not memoized and gets invoked even after tmp dir is wiped via LakeshoreTesting
+  # https://cits.artic.edu/issues/2943
+  let!(:file) do
     ActionDispatch::Http::UploadedFile.new(filename:     "sun.png",
                                            content_type: "image/png",
                                            tempfile:     File.new(File.join(fixture_path, "sun.png")))

--- a/spec/support/lakeshore_testing.rb
+++ b/spec/support/lakeshore_testing.rb
@@ -3,11 +3,11 @@ class LakeshoreTesting
   class << self
     # Removes all resources from Fedora and Solr and restores
     # the repository to a minimal testing state
-    def restore(reset_tmp_files: true)
+    def restore
       ActiveFedora::Cleaner.clean!
       cleanout_redis
       reset_derivatives
-      reset_uploads if reset_tmp_files
+      reset_uploads
       create_minimal_resources
       ListManager.new(File.join(Rails.root, "config/lists/status.yml")).create
       ActiveFedora::Base.all.map(&:update_index)


### PR DESCRIPTION
# REDMINE URL: https://cits.artic.edu/issues/2943