### PR TITLE
remove resetting of tmp uploads and see if upsets anything

### DIFF
--- a/spec/support/lakeshore_testing.rb
+++ b/spec/support/lakeshore_testing.rb
@@ -7,7 +7,7 @@ class LakeshoreTesting
       ActiveFedora::Cleaner.clean!
       cleanout_redis
       reset_derivatives
-      reset_uploads
+      # reset_uploads
       create_minimal_resources
       ListManager.new(File.join(Rails.root, "config/lists/status.yml")).create
       ActiveFedora::Base.all.map(&:update_index)


### PR DESCRIPTION
I'm having the weirdest problems with tmp files not being available in my feature test. I can't seem to escape `Errno::ENOENT - No such file or directory`. I don't see why on LakeshoreTesting.restore's why we'd have to toast the tmp files if they are just going to take time to write to disk in the same path. But I don't know, maybe if the file exists already, the new binary overwrites anyhow?

I commented out the tmp dir reset inside LakeshoreTesting.restore, just in case in some other places the use of `reset_uploads` is explicitly needed.

The feature suite runs 90-120 (15%) seconds faster, and is green, after running two builds in a row.

@awead do you see any problems with this change? It has really slowed down 1686, and I think I can now actually write tests and finish this damn thing.