### PR TITLE
Adding batch upload to IngestFile

### DIFF
--- a/app/models/lakeshore/ingest_file.rb
+++ b/app/models/lakeshore/ingest_file.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Lakeshore
   class IngestFile
-    attr_reader :file, :type, :user
+    attr_reader :file, :type, :user, :batch_id
 
     delegate :original_filename, to: :file
     delegate :errors, to: :uploaded_file
@@ -22,10 +22,12 @@ module Lakeshore
     # @param [User] user depositor performing the ingest from the API
     # @param [ActionDispatch::Http::UploadedFile] file uploaded from the API
     # @param [Symbol] type for the FileSet that has a registered URI
-    def initialize(user:, file:, type:)
+    # @param [UploadedBatch] batch id for the Sufia::UploadedFile
+    def initialize(user:, file:, type:, batch_id:)
       @type = type
       @file = file
       @user = user
+      @batch_id = batch_id
     end
 
     def uri
@@ -59,7 +61,7 @@ module Lakeshore
 
       def create_file(file, user)
         return if file.nil?
-        Sufia::UploadedFile.create(file: file, user: user, use_uri: uri)
+        Sufia::UploadedFile.create(file: file, user: user, use_uri: uri, uploaded_batch_id: batch_id)
       end
 
       class UnsupportedFileSetTypeError < StandardError; end

--- a/app/models/lakeshore/ingest_registry.rb
+++ b/app/models/lakeshore/ingest_registry.rb
@@ -45,7 +45,7 @@ module Lakeshore
     private
 
       def register_intermediate_file(file, user)
-        file = IngestFile.new(user: user, file: file, type: :intermediate)
+        file = IngestFile.new(user: user, file: file, type: :intermediate, batch_id: uploaded_batch.id)
         return if file.file.nil?
         file
       end
@@ -53,11 +53,11 @@ module Lakeshore
       # @note creates ingest files for both typed and non-typed files
       def register_files(content)
         (content.keys.map(&:to_sym) & IngestFile.types).each do |type|
-          files << IngestFile.new(user: user, file: content.delete(type), type: type)
+          files << IngestFile.new(user: user, file: content.delete(type), type: type, batch_id: uploaded_batch.id)
         end
 
         content.values.map do |file|
-          files << IngestFile.new(user: user, file: file, type: nil)
+          files << IngestFile.new(user: user, file: file, type: nil, batch_id: uploaded_batch.id)
         end
       end
 
@@ -71,6 +71,10 @@ module Lakeshore
                  "#{file.errors.messages[:checksum].first[:duplicate_name]}",
           path: file.errors.messages[:checksum].first[:duplicate_path]
         }
+      end
+
+      def uploaded_batch
+        @uploaed_batch ||= UploadedBatch.create
       end
   end
 end

--- a/spec/models/lakeshore/ingest_file_spec.rb
+++ b/spec/models/lakeshore/ingest_file_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Lakeshore::IngestFile do
                                            tempfile:     File.new(File.join(fixture_path, "sun.png")))
   end
 
-  subject { described_class.new(file: file, user: user, type: type) }
+  subject { described_class.new(file: file, user: user, type: type, batch_id: UploadedBatch.create.id) }
 
   it { is_expected.to delegate_method(:original_filename).to(:file) }
   it { is_expected.to delegate_method(:errors).to(:uploaded_file) }
@@ -54,7 +54,7 @@ RSpec.describe Lakeshore::IngestFile do
       let(:type) { :unregistered }
       it "raises an error" do
         expect {
-          described_class.new(file: file, user: user, type: :unregistered).uri
+          described_class.new(file: file, user: user, type: :unregistered, batch_id: UploadedBatch.create.id).uri
         }.to raise_error(Lakeshore::IngestFile::UnsupportedFileSetTypeError,
                          "'unregistered' is not a supported file set type")
       end


### PR DESCRIPTION
# REDMINE URL: https://cits.artic.edu/issues/2773

Adds batch upload id to the IngestFile so we can catch duplicate uploads in the same batch.
