### PR TITLE
Don't memoize calls to duplicate_file_sets in ChecksumValidator

### DIFF
--- a/app/validators/checksum_validator.rb
+++ b/app/validators/checksum_validator.rb
@@ -53,9 +53,7 @@ class ChecksumValidator < ActiveModel::Validator
 
     # @return [Array<FileSet>]
     def duplicate_file_sets
-      @duplicate_file_sets ||= begin
-                                 return [] if record.file.nil?
-                                 FileSet.where(digest_ssim: record.checksum)
-                               end
+      return [] if record.file.nil?
+      FileSet.where(digest_ssim: record.checksum)
     end
 end


### PR DESCRIPTION
After pairing up on some duplicate problems, we discovered that Solr was getting called multiple times during the validation process. We should not save the result of the Solr query because the first time it queries it, it may not have the value we're looking for.