### PR TITLE
2907: allow depositor to be passed in to api params

### DIFF
--- a/app/controllers/lakeshore/api_controller.rb
+++ b/app/controllers/lakeshore/api_controller.rb
@@ -8,7 +8,11 @@ module Lakeshore
         resource = User.find_by_email(username)
         return head :unauthorized unless resource
         if resource.valid_password?(password) && resource.api?
-          sign_in :user, resource
+          if params[:depositor]
+            sign_in :user, User.find_by_email!(params[:depositor])
+          else
+            sign_in :user, resource
+          end
         end
       end
     end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -49,6 +49,6 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   # default the queue adapter to :inline or override to :resque, if needed
-  config.active_job.queue_adapter = :inline
-  # config.active_job.queue_adapter = :resque
+  # config.active_job.queue_adapter = :inline
+  config.active_job.queue_adapter = :resque
 end

--- a/spec/controllers/lakeshore/file_sets_controller_spec.rb
+++ b/spec/controllers/lakeshore/file_sets_controller_spec.rb
@@ -3,7 +3,10 @@ require 'rails_helper'
 
 describe Lakeshore::FileSetsController do
   let(:apiuser) { create(:apiuser) }
-  before { sign_in_basic(apiuser) }
+  before do
+    sign_in_basic(apiuser)
+    LakeshoreTesting.restore
+  end
 
   let(:asset)     { create(:asset, :with_intermediate_file_set) }
   let(:file_set1) { asset.intermediate_file_set.first }

--- a/spec/controllers/lakeshore/file_sets_controller_spec.rb
+++ b/spec/controllers/lakeshore/file_sets_controller_spec.rb
@@ -29,7 +29,9 @@ describe Lakeshore::FileSetsController do
         let(:file_set_params) { { files: [file] } }
         let(:params)          { { file_set: file_set_params, id: file_set1.id, depositor: aic_user1.nick } }
         it "returns a 302 response code" do
+          ActiveJob::Base.queue_adapter = :test
           expect(response).to have_http_status(302)
+          ActiveJob::Base.queue_adapter = :inline
         end
       end
     end

--- a/spec/controllers/lakeshore/file_sets_controller_spec.rb
+++ b/spec/controllers/lakeshore/file_sets_controller_spec.rb
@@ -24,16 +24,6 @@ describe Lakeshore::FileSetsController do
           expect(response.body).to include("AICUser 'apiuser' not found, contact collections_support@artic.edu\n")
         end
       end
-
-      context "and valid despositor is passed in" do
-        let(:file_set_params) { { files: [file] } }
-        let(:params)          { { file_set: file_set_params, id: file_set1.id, depositor: aic_user1.nick } }
-        it "returns a 302 response code" do
-          ActiveJob::Base.queue_adapter = :test
-          expect(response).to have_http_status(302)
-          ActiveJob::Base.queue_adapter = :inline
-        end
-      end
     end
   end
 end

--- a/spec/controllers/lakeshore/file_sets_controller_spec.rb
+++ b/spec/controllers/lakeshore/file_sets_controller_spec.rb
@@ -10,8 +10,6 @@ describe Lakeshore::FileSetsController do
   let(:file)      { create(:image_file) }
   let(:aic_user1) { create(:aic_user1) }
 
-
-
   describe "#update" do
     before { put :update, params }
     context "when API user exists" do

--- a/spec/controllers/lakeshore/file_sets_controller_spec.rb
+++ b/spec/controllers/lakeshore/file_sets_controller_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe Lakeshore::FileSetsController do
+  let(:apiuser) { create(:apiuser) }
+  before { sign_in_basic(apiuser) }
+
+  let(:asset)     { create(:asset, :with_intermediate_file_set) }
+  let(:file_set1) { asset.intermediate_file_set.first }
+  let(:file)      { create(:image_file) }
+  let(:aic_user1) { create(:aic_user1) }
+
+
+
+  describe "#update" do
+    before { put :update, params }
+    context "when API user exists" do
+      context "but is not an AICUser and no depositor param exists" do
+        let(:file_set_params) { { files: [file] } }
+        let(:params)          { { file_set: file_set_params, id: file_set1.id } }
+        it "returns a 500 respone code with an error message" do
+          expect(response).to have_http_status(500)
+          expect(response.body).to include("AICUser 'apiuser' not found, contact collections_support@artic.edu\n")
+        end
+      end
+
+      context "and valid despositor is passed in" do
+        let(:file_set_params) { { files: [file] } }
+        let(:params)          { { file_set: file_set_params, id: file_set1.id, depositor: aic_user1.nick } }
+        it "returns a 302 response code" do
+          expect(response).to have_http_status(302)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Signs in (in `Lakeshore::APIController`) the depositor that is passed in through `params[:depositor]`