### PR TITLE
Update status on files uploaded via API

### DIFF
--- a/app/controllers/lakeshore/ingest_controller.rb
+++ b/app/controllers/lakeshore/ingest_controller.rb
@@ -11,6 +11,8 @@ module Lakeshore
     before_action :validate_ingest, :validate_asset_type, only: [:create]
     before_action :validate_duplicate_upload, :validate_preferred_representations, only: [:create, :update]
 
+    after_action :set_ingest_status, only: [:create]
+
     def create
       if actor.create(attributes_for_actor)
         head :accepted
@@ -49,6 +51,10 @@ module Lakeshore
         return if force_preferred_representation? || represented_resources.empty?
         ingest.errors.add(:represented_resources, "#{represented_resources.join(', ')} already have a preferred representation")
         render json: ingest.errors.full_messages, status: :conflict
+      end
+
+      def set_ingest_status
+        Sufia::UploadedFile.change_status(ingest.files, "begun_ingestion")
       end
 
     private

--- a/spec/controllers/lakeshore/ingest_controller/create_spec.rb
+++ b/spec/controllers/lakeshore/ingest_controller/create_spec.rb
@@ -25,6 +25,7 @@ describe Lakeshore::IngestController, custom_description: "Lakeshore::IngestCont
       expect(Lakeshore::AttachFilesToWorkJob).to receive(:perform_later)
       post :create, asset_type: "StillImage", content: { intermediate: image_asset }, metadata: metadata
       expect(response).to be_accepted
+      expect(Sufia::UploadedFile.all.first.status).to eq("begun_ingestion")
     end
   end
 

--- a/tasks/dev.rake
+++ b/tasks/dev.rake
@@ -7,11 +7,10 @@ namespace :dev do
     ActiveFedora::Cleaner.clean!
     cleanout_redis
     clear_directories
-    User.destroy_all
   end
 
   desc "Prep dev environment"
-  task prep: ['db:migrate', :clean, 'lakeshore:load_lists', 'fedora:create_users', 'fedora:create_citi_resources']
+  task prep: ['db:reset', :clean, 'lakeshore:load_lists', 'fedora:create_users', 'fedora:create_citi_resources']
 end
 
 namespace :fedora do


### PR DESCRIPTION
File that are uploaded via the API should have their status set to "begun_ingestion" once they have been submitted.

Additionally, this PR adjusts the dev:prep task to clean out the ActiveRecord database as well.

# REDMINE URL: https://cits.artic.edu/issues/2773
