### PR TITLE
Don't allow unregistered file types in the ingest API

### DIFF
--- a/app/models/lakeshore/ingest.rb
+++ b/app/models/lakeshore/ingest.rb
@@ -8,6 +8,8 @@ module Lakeshore
 
     validates :ingestor, :asset_type, :document_type_uri, :intermediate_file, presence: true
 
+    validate :registry_must_be_valid
+
     delegate :intermediate_file, :duplicate_error, to: :registry
 
     # @param [ActionController::Parameters] params from the controller
@@ -76,6 +78,11 @@ module Lakeshore
         @document_type_uri = metadata.fetch(:document_type_uri, nil)
         @preferred_representation_for = metadata.fetch(:preferred_representation_for, [])
         @ingestor = find_or_create_user(metadata.fetch(:depositor, nil))
+      end
+
+      def registry_must_be_valid
+        return if registry.valid?
+        registry.errors.full_messages.each { |error| errors.add(:registry, error) }
       end
 
       def find_or_create_user(key)

--- a/app/models/lakeshore/ingest_file.rb
+++ b/app/models/lakeshore/ingest_file.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Lakeshore
   class IngestFile
-    attr_reader :file, :type, :user, :batch_id
+    attr_reader :file, :type, :user, :batch_id, :uri
 
     delegate :original_filename, to: :file
     delegate :errors, to: :uploaded_file
@@ -28,10 +28,7 @@ module Lakeshore
       @file = file
       @user = user
       @batch_id = batch_id
-    end
-
-    def uri
-      @uri ||= register_uri
+      @uri = register_uri
     end
 
     def duplicate?

--- a/spec/controllers/lakeshore/ingest_controller/create_spec.rb
+++ b/spec/controllers/lakeshore/ingest_controller/create_spec.rb
@@ -61,6 +61,16 @@ describe Lakeshore::IngestController, custom_description: "Lakeshore::IngestCont
     its(:body) { is_expected.to eq("[\"Ingestor can't be blank\",\"Document type uri can't be blank\",\"Intermediate file can't be blank\"]") }
   end
 
+  context 'with an unsupported file set type' do
+    it "returns an error" do
+      post :create, asset_type: "StillImage",
+                    content: { intermediate: image_asset, bogus: image_asset },
+                    metadata: metadata
+      expect(response).to be_bad_request
+      expect(response.body).to eq("[\"Registry Files Request contains invalid file types: bogus\"]")
+    end
+  end
+
   describe "asset type validation" do
     subject { response }
 

--- a/spec/models/lakeshore/ingest_file_spec.rb
+++ b/spec/models/lakeshore/ingest_file_spec.rb
@@ -35,12 +35,12 @@ RSpec.describe Lakeshore::IngestFile do
       its(:uri) { is_expected.to eq(AICType.IntermediateFileSet) }
     end
 
-    context "with an original file" do
+    context "with a preservation master file" do
       let(:type) { :pres_master }
       its(:uri) { is_expected.to eq(AICType.PreservationMasterFileSet) }
     end
 
-    context "with an original file" do
+    context "with a legacy file" do
       let(:type) { :legacy }
       its(:uri) { is_expected.to eq(AICType.LegacyFileSet) }
     end
@@ -54,7 +54,7 @@ RSpec.describe Lakeshore::IngestFile do
       let(:type) { :unregistered }
       it "raises an error" do
         expect {
-          described_class.new(file: file, user: user, type: :unregistered, batch_id: UploadedBatch.create.id).uri
+          described_class.new(file: file, user: user, type: :unregistered, batch_id: UploadedBatch.create.id)
         }.to raise_error(Lakeshore::IngestFile::UnsupportedFileSetTypeError,
                          "'unregistered' is not a supported file set type")
       end

--- a/spec/models/lakeshore/ingest_registry_spec.rb
+++ b/spec/models/lakeshore/ingest_registry_spec.rb
@@ -43,9 +43,7 @@ describe Lakeshore::IngestRegistry do
     context "with both named and non-named file types in the api request" do
       let(:content) { { intermediate: "intermediate file", pres_master: "pres master file", other: "other file" } }
 
-      it "is an array of ingest files" do
-        expect(registry.files.count).to eq(3)
-      end
+      it { is_expected.not_to be_valid }
     end
 
     context "with only named file types in the api request" do


### PR DESCRIPTION
This changes the ingest so you cannot upload arbitrary file types. We
still need to allow null file types, but this will be addressed later.

# REDMINE URL: https://cits.artic.edu/issues/2773

### QUESTIONS/TODO's
- [ ] We still need to allow null file types
