### PR TITLE
don't pass the ActionDigest::HTTP::UploadedFile to the actor

### DIFF
--- a/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
+++ b/app/controllers/concerns/curation_concerns/file_sets_controller_behavior.rb
@@ -87,7 +87,7 @@ module CurationConcerns
                     sufia_uploaded_file = Sufia::UploadedFile.new(file: file,
                                                                   uploaded_batch_id: UploadedBatch.create.id,
                                                                   user: current_user)
-                    sufia_uploaded_file.valid? ? actor.update_content(file) : false
+                    sufia_uploaded_file.valid? ? actor.update_content(sufia_uploaded_file.file) : false
                   else
                     update_metadata
                   end


### PR DESCRIPTION
this is a small improvement. in the ticket where I added duplicate checking validation on the file_set version upload GUI page, I was passing in the /var/rack file and not the cached tmp/uploads file. The rack file can be gone by the time the actor stack processes it so we should always pass the sanitized CarrierWave file that the model points to.