### PR TITLE
Update sqlite3 gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -657,7 +657,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.3.12)
+    sqlite3 (1.3.13)
     sshkit (1.11.4)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
@@ -785,4 +785,4 @@ DEPENDENCIES
   xray-rails
 
 BUNDLED WITH
-   1.16.0
+   1.16.3


### PR DESCRIPTION
Sqlite 3.24.0 provided by brew requires the latest version of the gem.
