### PR TITLE
install bundler gem needs to use HTTP_PROXY

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -72,7 +72,7 @@ namespace :deploy do
   # make sure bundler is installed (for new rubies etc)
   before :started, :install_bundler do
     on roles(:web) do
-      execute "gem install bundler --conservative"
+      execute "HTTP_PROXY=#{fetch(:aic_proxy)} gem install bundler --conservative"
     end
   end
 


### PR DESCRIPTION
new cap task to install bundler gem failed. needs proxy explicitly in the task.