### PR TITLE
Add script to update group edit permissions

### DIFF
--- a/app/jobs/add_edit_group_permission_job.rb
+++ b/app/jobs/add_edit_group_permission_job.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+class AddEditGroupPermissionJob < ActiveJob::Base
+  queue_as :release
+
+  class Error < StandardError; end
+
+  def perform(uid:, group:)
+    raise Error, "Department id #{group} does not exist" unless Department.find_by_citi_uid(group)
+    asset = GenericWork.find(service.hash(uid))
+    edit_groups = asset.edit_groups
+    return if edit_groups.include?(group)
+    new_groups = edit_groups + [group]
+    asset.edit_groups = new_groups
+    asset.save
+    asset.file_sets.map(&:update_index)
+  end
+
+  private
+
+    def service
+      @service ||= UidMinter.new
+    end
+end

--- a/script/update-permissions.rb
+++ b/script/update-permissions.rb
@@ -1,0 +1,25 @@
+# Reads in csv file and updates permissions
+# @example To update all the assets in a csv granting department 246 edit access:
+#   bundle exec rails runner script/update-permissions.rb file.csv 246
+
+class PermissionFile
+  attr_reader :path
+
+  def initialize(path = ARGV[0])
+    @path = path
+  end
+
+  def assets
+    rows.map(&:last).uniq
+  end
+
+  private
+
+    def rows
+      @rows ||= CSV.read(path, col_sep: "\t")
+    end
+end
+
+PermissionFile.new.assets.each do |uid|
+  AddEditGroupPermissionJob.perform_later(uid: uid, group: ARGV[1])
+end

--- a/spec/jobs/add_edit_group_permission_job_spec.rb
+++ b/spec/jobs/add_edit_group_permission_job_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+describe AddEditGroupPermissionJob do
+  context 'when uid does not exist' do
+    let(:job) { described_class.new(uid: 'bogus', group: '100') }
+
+    it 'raises an error' do
+      expect { job.perform_now }.to raise_error(ActiveFedora::ObjectNotFoundError)
+    end
+  end
+
+  context 'when group id does not exist' do
+    let(:job) { described_class.new(uid: 'SI-12345678', group: '2') }
+    let(:asset) { build(:asset, uid: 'SI-12345678') }
+
+    before { allow(GenericWork).to receive(:find).and_return(asset) }
+
+    it 'raises an error' do
+      expect {
+        job.perform_now
+      }.to raise_error(AddEditGroupPermissionJob::Error, "Department id 2 does not exist")
+    end
+  end
+
+  context 'when group already has edit access' do
+    let(:job) { described_class.new(uid: 'SI-12345678', group: '100') }
+    let(:asset) { build(:asset, uid: 'SI-12345678') }
+
+    before { allow(GenericWork).to receive(:find).and_return(asset) }
+
+    it 'does not update the asset' do
+      expect(asset).not_to receive(:save)
+      expect(job.perform_now).to be_nil
+    end
+  end
+
+  context 'when adding a new group' do
+    let(:job) { described_class.new(uid: 'SI-12345678', group: '200') }
+    let(:asset) { build(:asset, uid: 'SI-12345678') }
+
+    before { allow(GenericWork).to receive(:find).and_return(asset) }
+
+    it 'updates the asset' do
+      expect(asset).to receive(:save)
+      job.perform_now
+      expect(asset.edit_groups).to include("200")
+    end
+  end
+end


### PR DESCRIPTION
## Description

Creates a job that updates permissions for a specific department. Uses a script to read a csv file to queue the job for each unique asset found in the csv.

## Redmine

https://cits.artic.edu/issues/2792
